### PR TITLE
publisher: add long-lived retry policy

### DIFF
--- a/xivo_bus/__init__.py
+++ b/xivo_bus/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2013-2016 Avencall
+# Copyright 2013-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_bus.marshaler import CollectdMarshaler, Marshaler  # noqa
-from xivo_bus.publisher import Publisher  # noqa
+from xivo_bus.publisher import Publisher, FailFastPublisher, LongLivedPublisher  # noqa
 from xivo_bus.publishing_queue import PublishingQueue  # noqa

--- a/xivo_bus/publisher.py
+++ b/xivo_bus/publisher.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2012-2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -8,17 +8,18 @@ logger = logging.getLogger(__name__)
 
 
 class Publisher(object):
-
-    def __init__(self, producer, marshaler):
-        self._publish = self._new_publish(producer)
+    def __init__(self, producer, marshaler, **connection_args):
         self._marshaler = marshaler
+        self._publish = self._new_publish(producer, connection_args)
 
-    def _new_publish(self, producer):
+    def _new_publish(self, producer, connection_args):
         conn = producer.connection
-        return conn.ensure(producer, producer.publish,
-                           errback=self._on_publish_error,
-                           max_retries=2,
-                           interval_start=1)
+        return conn.ensure(
+            producer,
+            producer.publish,
+            errback=self._on_publish_error,
+            **connection_args
+        )
 
     def _on_publish_error(self, exc, interval):
         logger.error('Error: %s', exc, exc_info=1)
@@ -28,7 +29,25 @@ class Publisher(object):
         data = self._marshaler.marshal_message(event)
         all_headers = dict(self._marshaler.metadata(event))
         all_headers.update(headers or {})
-        self._publish(data,
-                      content_type=self._marshaler.content_type,
-                      routing_key=event.routing_key,
-                      headers=all_headers)
+        self._publish(
+            data,
+            content_type=self._marshaler.content_type,
+            routing_key=event.routing_key,
+            headers=all_headers,
+        )
+
+
+class FailFastPublisher(Publisher):
+    def __init__(self, producer, marshaler):
+        super(FailFastPublisher, self).__init__(producer, marshaler, max_retries=2)
+
+
+class LongLivedPublisher(Publisher):
+    def __init__(self, producer, marshaler):
+        super(LongLivedPublisher, self).__init__(
+            producer,
+            marshaler,
+            interval_start=2,
+            interval_step=2,
+            interval_max=32,
+        )


### PR DESCRIPTION
Why:

* Some daemons need a bus publisher that will retry forever (e.g. wazo-amid)