### PR TITLE
Pull request for WAZO-2569-meeting-progress-event

### DIFF
--- a/xivo_bus/resources/asterisk/event.py
+++ b/xivo_bus/resources/asterisk/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..common.event import BaseEvent
@@ -10,10 +10,11 @@ class AsteriskReloadProgressEvent(BaseEvent):
     name = 'asterisk_reload_progress'
     routing_key_fmt = 'sysconfd.asterisk.reload.{uuid}.{status}'
 
-    def __init__(self, uuid, status, command):
+    def __init__(self, uuid, status, command, request_uuids):
         self._body = {
             'uuid': uuid,
             'status': status,
             'command': command,
+            'request_uuids': request_uuids,
         }
         super(AsteriskReloadProgressEvent, self).__init__()

--- a/xivo_bus/resources/asterisk/tests/test_event.py
+++ b/xivo_bus/resources/asterisk/tests/test_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -12,13 +12,16 @@ from ..event import AsteriskReloadProgressEvent
 ASTERISK_UUID = str(uuid.uuid4)
 STATUS = 'starting'
 COMMAND = 'core reload'
+REQUEST_UUIDS = [
+    'cf0a6633-be41-4fda-9ac9-3eef74b9ab88',
+    '6b6b0456-8580-4476-89ea-250e8f555a93',
+]
 
 
 class TestUserVoicemailEvent(unittest.TestCase):
-
     def test_reload_routing_key_fmt(self):
-        msg = AsteriskReloadProgressEvent(ASTERISK_UUID, STATUS, COMMAND)
+        msg = AsteriskReloadProgressEvent(ASTERISK_UUID, STATUS, COMMAND, REQUEST_UUIDS)
         assert_that(
             msg.routing_key,
-            equal_to('sysconfd.asterisk.reload.{}.{}'.format(ASTERISK_UUID, STATUS))
+            equal_to('sysconfd.asterisk.reload.{}.{}'.format(ASTERISK_UUID, STATUS)),
         )

--- a/xivo_bus/resources/meeting/event.py
+++ b/xivo_bus/resources/meeting/event.py
@@ -27,6 +27,27 @@ class DeleteMeetingEvent(_BaseMeetingEvent):
     routing_key_fmt = 'config.meetings.deleted'
 
 
+class MeetingProgressEvent(BaseEvent):
+    name = 'meeting_progress'
+    routing_key_fmt = 'config.meetings.progress'
+
+    def __init__(self, meeting, status):
+        self._body = dict(meeting)
+        self._body['status'] = status
+        super(MeetingProgressEvent, self).__init__()
+
+
+class UserMeetingProgressEvent(BaseEvent):
+    name = 'meeting_user_progress'
+    routing_key_fmt = 'config.users.{user_uuid}.meetings.progress'
+
+    def __init__(self, meeting, user_uuid, status):
+        self._body = dict(meeting)
+        self._body['user_uuid'] = user_uuid
+        self._body['status'] = status
+        super(UserMeetingProgressEvent, self).__init__()
+
+
 class _BaseParticipantMeetingEvent(BaseEvent):
     def __init__(self, meeting_uuid, participant_dict):
         self._body = {'meeting_uuid': meeting_uuid}

--- a/xivo_bus/resources/sysconfd/event.py
+++ b/xivo_bus/resources/sysconfd/event.py
@@ -1,0 +1,18 @@
+# Copyright 2021 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from ..common.event import BaseEvent
+
+
+class RequestHandlersProgressEvent(BaseEvent):
+
+    name = 'request_handlers_progress'
+    routing_key_fmt = 'sysconfd.request_handlers.{uuid}.{status}'
+
+    def __init__(self, request, status):
+        self._body = {
+            'uuid': request.uuid,
+            'status': status,
+            'context': request.context,
+        }
+        super(RequestHandlersProgressEvent, self).__init__()


### PR DESCRIPTION
## asterisk reload: add request uuids

Why:

* Allows keeping track of which reload corresponds to which request

## add sysconfd request handlers progress event


## meetings: add progress events