### PR TITLE
WAZO-2496 Add Pause/Unpause events for wazo-agentd

### DIFF
--- a/xivo_bus/resources/agent/event.py
+++ b/xivo_bus/resources/agent/event.py
@@ -4,7 +4,7 @@
 
 from __future__ import unicode_literals
 
-from xivo_bus.resources.common.event import ResourceConfigEvent
+from xivo_bus.resources.common.event import ResourceConfigEvent, BaseEvent
 
 
 class EditAgentEvent(ResourceConfigEvent):
@@ -20,3 +20,35 @@ class CreateAgentEvent(ResourceConfigEvent):
 class DeleteAgentEvent(ResourceConfigEvent):
     name = 'agent_deleted'
     routing_key = 'config.agent.deleted'
+
+
+class PauseAgentEvent(BaseEvent):
+    name = 'agent_paused'
+    routing_key = 'status.agent.pause'
+    required_acl = 'events.statuses.agents'
+
+    def __init__(self, agent_id, agent_number, queue, reason=''):
+        self._body = dict(
+            agent_id=agent_id,
+            agent_number=agent_number,
+            paused=True,
+            paused_reason=reason,
+            queue=queue,
+        )
+        self.agent_id = agent_id
+
+
+class UnpauseAgentEvent(BaseEvent):
+    name = 'agent_unpaused'
+    routing_key = 'status.agent.unpause'
+    required_acl = 'events.statuses.agents'
+
+    def __init__(self, agent_id, agent_number, queue, reason=''):
+        self._body = dict(
+            agent_id=agent_id,
+            agent_number=agent_number,
+            paused=False,
+            paused_reason=reason,
+            queue=queue,
+        )
+        self.agent_id = agent_id

--- a/xivo_bus/resources/agent/event.py
+++ b/xivo_bus/resources/agent/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2015 Avencall
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -35,7 +35,6 @@ class PauseAgentEvent(BaseEvent):
             paused_reason=reason,
             queue=queue,
         )
-        self.agent_id = agent_id
 
 
 class UnpauseAgentEvent(BaseEvent):
@@ -51,4 +50,3 @@ class UnpauseAgentEvent(BaseEvent):
             paused_reason=reason,
             queue=queue,
         )
-        self.agent_id = agent_id


### PR DESCRIPTION
Why:

* Previously, pause/unpause events were generated using
ArbitraryEvent, which makes debugging harder.