### PR TITLE
WAZO-2498: Adds PushNotificationEvent to bus resources

### DIFF
--- a/xivo_bus/resources/push_notification/events.py
+++ b/xivo_bus/resources/push_notification/events.py
@@ -1,0 +1,14 @@
+# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0+
+
+from xivo_bus.resources.common.event import BaseEvent
+
+
+class PushNotificationEvent(BaseEvent):
+    name = 'call_push_notification'
+    routing_key_fmt = 'calls.call.push_notification'
+
+    def __init__(self, push_notification, user_uuid):
+        self._body = push_notification
+        super(PushNotificationEvent, self).__init__()
+        self.required_acl = 'events.calls.{uuid}'.format(uuid=user_uuid)


### PR DESCRIPTION
Why:
To replace ArbitraryEvent used in wazo_calld mobile push notification
subsystem