### PR TITLE
WAZO-2509 is_running now checks if bus_consumer is actuallly connected

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -18,6 +18,8 @@ services:
 
   bus:
     image: xivo-bus-test
+    volumes:
+      - ../..:/usr/src/xivo-bus
     ports:
       - "5000"
     environment:

--- a/integration_tests/docker/remote-bus-pilot.py
+++ b/integration_tests/docker/remote-bus-pilot.py
@@ -101,6 +101,11 @@ def make_response(code, status=None, **kwargs):
 #####################
 # Routes definition #
 #####################
+@app.route('/bus/status', methods=['GET'])
+def status():
+    return make_response(200, None, running=bus.is_running)
+
+
 @app.route('/bus/<string:event>/publish', methods=['POST'])
 def publish(event):
     headers, routing_key, payload = process_json(event, request.json)

--- a/integration_tests/suite/helpers/remote_bus.py
+++ b/integration_tests/suite/helpers/remote_bus.py
@@ -46,3 +46,7 @@ class RemoteBusApiClient:
     def get_messages_count(self, event):
         url = self._make_url('bus', event, 'messages', 'count')
         return requests.get(url).json()
+
+    def get_status(self):
+        url = self._make_url('bus', 'status')
+        return requests.get(url).json()

--- a/integration_tests/suite/helpers/wait_strategies.py
+++ b/integration_tests/suite/helpers/wait_strategies.py
@@ -1,0 +1,20 @@
+# Copyright 2022-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from wazo_test_helpers import until
+from kombu import Connection
+
+
+def wait_for_rabbitmq(integration_test):
+    def try_connect(connection):
+        try:
+            connection.connect()
+        except Exception:
+            return False
+        else:
+            connection.release()
+            return True
+
+    port = integration_test.service_port(5672, 'rabbitmq')
+    with Connection(f'amqp://guest:guest@127.0.0.1:{port}//') as connection:
+        until.true(try_connect, connection, timeout=30)

--- a/integration_tests/suite/test_status.py
+++ b/integration_tests/suite/test_status.py
@@ -1,8 +1,12 @@
 # Copyright 2022-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from hamcrest import assert_that, calling, raises, has_item, has_entry
 from wazo_test_helpers import until
+from kombu.exceptions import OperationalError
+
 from .helpers.base import BusIntegrationTest
+from .helpers.events import MockEvent
 
 
 class TestStatus(BusIntegrationTest):
@@ -15,12 +19,32 @@ class TestStatus(BusIntegrationTest):
     def test_status_when_all_ok(self):
         until.true(self.check_is_running, tries=3)
 
-    def test_reconnect_when_rabbitmq_restarts(self):
+    def test_status_when_rabbitmq_restarts(self):
         self.stop_rabbitmq()
         until.false(self.check_is_running, timeout=30)
         self.start_rabbitmq()
         until.true(self.check_is_running, timeout=30)
 
-    def test_reconnect_when_service_restart(self):
+    def test_status_when_service_restart(self):
         self.reset_clients()
         until.true(self.check_is_running, tries=3)
+
+    def test_publish_timeout_when_rabbitmq_is_down_then_up(self):
+        event = MockEvent('some_event', value='some_value')
+
+        self.stop_rabbitmq()
+
+        with self.local_event(event.name):
+            assert_that(
+                calling(self.local_bus.publish).with_args(event),
+                raises(OperationalError),
+            )
+
+            self.start_rabbitmq()
+            until.true(self.check_is_running, timeout=30)
+
+            self.local_bus.publish(event)
+            assert_that(
+                self.local_messages(event.name, 1),
+                has_item(has_entry('value', 'some_value')),
+            )

--- a/integration_tests/suite/test_status.py
+++ b/integration_tests/suite/test_status.py
@@ -1,0 +1,26 @@
+# Copyright 2022-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from wazo_test_helpers import until
+from .helpers.base import BusIntegrationTest
+
+
+class TestStatus(BusIntegrationTest):
+    asset = 'headers'
+
+    def check_is_running(self):
+        remote_status = self.remote_bus.get_status()
+        return self.local_bus.is_running and remote_status['running']
+
+    def test_status_when_all_ok(self):
+        until.true(self.check_is_running, tries=3)
+
+    def test_reconnect_when_rabbitmq_restarts(self):
+        self.stop_rabbitmq()
+        until.false(self.check_is_running, timeout=30)
+        self.start_rabbitmq()
+        until.true(self.check_is_running, timeout=30)
+
+    def test_reconnect_when_service_restart(self):
+        self.reset_clients()
+        until.true(self.check_is_running, tries=3)

--- a/xivo_bus/base.py
+++ b/xivo_bus/base.py
@@ -39,7 +39,7 @@ class Base(object):
 
     @property
     def is_running(self):
-        return False
+        return True
 
     def _marshal(self, event, headers, payload, routing_key=None):
         return headers, payload, routing_key

--- a/xivo_bus/base.py
+++ b/xivo_bus/base.py
@@ -3,7 +3,6 @@
 
 import logging
 
-from contextlib import contextmanager
 from collections import namedtuple
 from kombu import Exchange
 from kombu.utils.url import as_url
@@ -52,15 +51,3 @@ class Base(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         pass
-
-    @contextmanager
-    def _channel_autoretry(self, connection, retries=3):
-        for count in range(retries):
-            connection.ensure_connection(max_retries=1, reraise_as_library_errors=False)
-            try:
-                yield connection.default_channel
-            except connection.connection_errors:
-                self.log.error('Connection error, reconnecting (%d/%d)...', count + 1, retries)
-                continue
-            else:
-                break


### PR DESCRIPTION
Why: 
  * Previous implementation only checked if thread was alive, now property `is_running` also checks if connection with rabbitmq is alive