### PR TITLE
Expose the status of the connection used by the publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Running unit tests
 ```
 apt-get install libpq-dev python-dev libffi-dev libyaml-dev
 pip install tox
-tox --recreate -e py27,py3
+tox --recreate -e py37
 ```
 
 Running integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py37, pycodestyle, pylint
+envlist = py37, pycodestyle, pylint
 
 [testenv]
 commands =

--- a/xivo_bus/publisher.py
+++ b/xivo_bus/publisher.py
@@ -65,7 +65,9 @@ class BusPublisherWithQueue(WazoEventMixin, ThreadableMixin, QueuePublisherMixin
 
 # Deprecated, use BusPublisher instead
 class Publisher(object):
+
     def __init__(self, producer, marshaler, **connection_args):
+        self._producer = producer
         self._marshaler = marshaler
         self._publish = self._new_publish(producer, connection_args)
 
@@ -93,6 +95,9 @@ class Publisher(object):
             routing_key=event.routing_key,
             headers=all_headers,
         )
+
+    def is_connected(self):
+        return self._producer.connection.connected
 
 
 # Deprecated, use BusPublisher instead

--- a/xivo_bus/publisher.py
+++ b/xivo_bus/publisher.py
@@ -5,25 +5,30 @@
 import logging
 
 from .base import Base
-from .mixins import QueuePublisherMixin, PublisherMixin, ThreadableMixin, WazoEventMixin
+from .mixins import (
+    QueuePublisherMixin,
+    PublisherMixin,
+    ThreadableMixin,
+    WazoEventMixin)
 
 logger = logging.getLogger(__name__)
 
 
 class BusPublisher(WazoEventMixin, PublisherMixin, Base):
+
     def __init__(
-        self,
-        name=None,
-        service_uuid=None,
-        username='guest',
-        password='guest',
-        host='localhost',
-        port=5672,
-        exchange_name='',
-        exchange_type='',
-        **kwargs
+            self,
+            name=None,
+            service_uuid=None,
+            username='guest',
+            password='guest',
+            host='localhost',
+            port=5672,
+            exchange_name='',
+            exchange_type='',
+            **kwargs
     ):
-        super(BusPublisher, self).__init__(
+        super().__init__(
             name=name,
             service_uuid=service_uuid,
             username=username,
@@ -37,20 +42,25 @@ class BusPublisher(WazoEventMixin, PublisherMixin, Base):
 
 
 # Deprecated, thread should be avoided to respect WPEP-0004
-class BusPublisherWithQueue(WazoEventMixin, ThreadableMixin, QueuePublisherMixin, Base):
+class BusPublisherWithQueue(
+    WazoEventMixin,
+    ThreadableMixin,
+    QueuePublisherMixin,
+    Base):
+
     def __init__(
-        self,
-        name=None,
-        service_uuid=None,
-        username='guest',
-        password='guest',
-        host='localhost',
-        port=5672,
-        exchange_name='',
-        exchange_type='',
-        **kwargs
+            self,
+            name=None,
+            service_uuid=None,
+            username='guest',
+            password='guest',
+            host='localhost',
+            port=5672,
+            exchange_name='',
+            exchange_type='',
+            **kwargs
     ):
-        super(BusPublisherWithQueue, self).__init__(
+        super().__init__(
             name=name,
             service_uuid=service_uuid,
             username=username,
@@ -102,13 +112,19 @@ class Publisher(object):
 
 # Deprecated, use BusPublisher instead
 class FailFastPublisher(Publisher):
+
     def __init__(self, producer, marshaler):
-        super(FailFastPublisher, self).__init__(producer, marshaler, max_retries=2)
+        super().__init__(producer, marshaler, max_retries=2)
 
 
 # Deprecated, use BusPublisher instead
 class LongLivedPublisher(Publisher):
+
     def __init__(self, producer, marshaler):
-        super(LongLivedPublisher, self).__init__(
-            producer, marshaler, interval_start=2, interval_step=2, interval_max=32
+        super().__init__(
+            producer,
+            marshaler,
+            interval_start=2,
+            interval_step=2,
+            interval_max=32
         )

--- a/xivo_bus/tests/test_publisher.py
+++ b/xivo_bus/tests/test_publisher.py
@@ -49,3 +49,7 @@ class TestPublisher(unittest.TestCase):
         self.marshaler.marshal_message.assert_called_once_with(event)
         self.publish.assert_called_once_with(
             sentinel.data, routing_key='foobar', headers=expected_headers, content_type='bazglop')
+
+    def test_publisher_is_connected(self):
+        self.producer.connection.connected = True
+        assert self.publisher.is_connected()


### PR DESCRIPTION
Before this update, the only way to know the status of the connection
was to store the connection outside the publisher and to use
'connection.connected'.

With this update, the status of the connection (connected or not)
is directly accessible from the publisher.