### PR TITLE
Pull request for consumer-running-status

### DIFF
--- a/xivo_bus/consumer.py
+++ b/xivo_bus/consumer.py
@@ -29,3 +29,10 @@ class BusConsumer(WazoEventMixin, ThreadableMixin, ConsumerMixin, Base):
             subscribe=subscribe,
             **kwargs
         )
+
+    def is_running(self):
+        return (
+            super(ThreadableMixin, self).is_running()
+            and super(ConsumerMixin, self).is_running()
+            and super(Base, self).is_running()
+        )

--- a/xivo_bus/mixins.py
+++ b/xivo_bus/mixins.py
@@ -29,8 +29,7 @@ class ThreadableMixin(object):
 
     @property
     def is_running(self):
-        status = all({bus_thread.thread.is_alive() for bus_thread in self.__threads})
-        return super(ThreadableMixin, self).is_running and status
+        return all({bus_thread.thread.is_alive() for bus_thread in self.__threads})
 
     @property
     def __threads(self):
@@ -270,10 +269,9 @@ class ConsumerMixin(KombuConsumer):
     @property
     def is_running(self):
         try:
-            is_running = self.connection.connected
+            return self.connection.connected
         except AttributeError:
-            is_running = False
-        return super(ConsumerMixin, self).is_running and is_running
+            return False
 
     @property
     def should_stop(self):


### PR DESCRIPTION
## consumer: combine is_running status from different sources

Why:

* In multiple inheritance cases, Python will only run one of the parents
methods.

## mixins: remove extraneous super()