### PR TITLE
pin importlib_metadata package

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -4,5 +4,6 @@ pytest
 requests
 
 # From xivo-bus
+importlib_metadata==1.6.0  # from kombu
 kombu==4.6.11
 six==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-six==1.12.0
+importlib_metadata==1.6.0  # from kombu
 kombu==4.6.11
+six==1.12.0


### PR DESCRIPTION
why: kombu use this library without pinning, and the latest version
(5.0.0) of importlib_metadata break the API.
We pin the library to the same version of current (buster) debian version