### PR TITLE
pin importlib-metadata in docker

### DIFF
--- a/contribs/README.md
+++ b/contribs/README.md
@@ -1,0 +1,20 @@
+# AsyncAPI Documentation Generator
+
+This role of this docker is to parse and generate asyncapi documentation for 
+all events found in the `xivo_bus/resources` directory.
+
+## Usage
+
+1. build the image
+
+`docker build -t wazo-asyncapi -f docker/Dockerfile .`
+
+1. run the image to parse and write asyncapi specification files to output
+
+`docker run -v ${output_dir}:/app/output -i wazo-asyncapi -p ${stack_version}`
+
+where: 
+  * output_dir: absolute path to where you want to extract the asyncapi documentation
+  * stack_version: version to write in the specification files
+
+The docker will then append and write each event's documentation to its microservice specification file.

--- a/contribs/docker/Dockerfile
+++ b/contribs/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN true \
     && mkdir -p /app/output \
     && install -dm777 /app/output \
-    && pip install --upgrade pip pyyaml kombu six \
+    && pip install --upgrade pip pyyaml 'importlib-metadata<5' kombu six \
         https://github.com/wazo-platform/xivo-bus/archive/master.zip
 
 COPY asyncapi-template.yml /app


### PR DESCRIPTION
Why:

* importlib-metadata > 5 breaks import on kombu