### PR TITLE
WAZO-3568: documentation use annotations

### DIFF
--- a/contribs/Dockerfile
+++ b/contribs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye
+FROM python:3.10-slim-bullseye
 LABEL maintainer="Wazo Maintainers <dev@wazo.community>"
 
 RUN python -m venv /opt/venv

--- a/contribs/documentation.py
+++ b/contribs/documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -15,7 +15,18 @@ from itertools import chain
 from pathlib import Path
 from sys import stdout
 from time import time
-from typing import Any
+from types import UnionType
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Literal,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+    is_typeddict,
+)
 
 import yaml
 from typing_extensions import TypeAlias
@@ -27,46 +38,118 @@ logger = logging.getLogger(__name__)
 
 
 class AsyncAPITypes:
-    @staticmethod
-    def string(*, many: bool = False) -> dict:
-        fmt = {'type': 'string'}
-        return AsyncAPITypes.array(fmt) if many else fmt
+    class Types:
+        @classmethod
+        def array(cls, format: dict[str, str]) -> dict:
+            return {'type': 'array', 'items': format}
 
-    @staticmethod
-    def boolean(*, many: bool = False) -> dict:
-        fmt = {'type': 'boolean'}
-        return AsyncAPITypes.array(fmt) if many else fmt
+        @classmethod
+        def boolean(cls) -> dict:
+            return {'type': 'boolean'}
 
-    @staticmethod
-    def integer(*, many: bool = False) -> dict:
-        fmt = {'type': 'integer'}
-        return AsyncAPITypes.array(fmt) if many else fmt
+        @classmethod
+        def datetime(cls) -> dict:
+            return cls.string(format='date-time')
 
-    @staticmethod
-    def float_(*, many: bool = False) -> dict:
-        fmt = {'type': 'float'}
-        return AsyncAPITypes.array(fmt) if many else fmt
+        @classmethod
+        def float_(cls) -> dict:
+            return {'type': 'float'}
 
-    @staticmethod
-    def uuid(*, many: bool = False) -> dict:
-        fmt = {'type': 'string', 'format': 'uuid'}
-        return AsyncAPITypes.array(fmt) if many else fmt
+        @classmethod
+        def integer(cls) -> dict:
+            return {'type': 'integer'}
 
-    @staticmethod
-    def datetime(*, many: bool = False) -> dict:
-        fmt = {'type': 'string', 'format': 'date-time'}
-        return AsyncAPITypes.array(fmt) if many else fmt
+        @classmethod
+        def object_(cls, content: dict | None = None) -> dict:
+            return {'type': 'object', 'properties': content or {}}
 
-    @staticmethod
-    def array(type_: Any) -> dict:
-        return {'type': 'array', 'items': type_}
+        @classmethod
+        def string(cls, *, format: str | None = None, const: str | None = None) -> dict:
+            content = {'type': 'string'}
+            if format:
+                content['format'] = format
+            if const:
+                content['const'] = const
+            return content
 
-    @staticmethod
-    def object_(dict_: dict | None = None) -> dict:
-        return {'type': 'object', 'properties': dict_ or {}}
+        @classmethod
+        def uuid(cls) -> dict:
+            return cls.string(format='uuid')
+
+    _TYPES_FACTORIES: dict[type | Any, Callable[..., dict]] = {
+        Any: Types.object_,
+        bool: Types.boolean,
+        dict: Types.object_,
+        float: Types.float_,
+        int: Types.integer,
+        str: Types.string,
+    }
+
+    @classmethod
+    def scan_hint(cls, hint: type) -> dict[str, str]:
+        def recurse(type_: type, metadata: dict | None = None) -> dict:
+            metadata = metadata or {}
+
+            if origin_type := get_origin(type_):
+                subtype, *args = get_args(type_)
+
+                if origin_type is Annotated:
+                    return recurse(subtype, metadata=args[0])
+
+                elif origin_type is Literal:
+                    return cls.Types.string(const=subtype)
+
+                elif origin_type in (UnionType, Union):
+                    return recurse(subtype)
+
+                elif origin_type in (list, set, tuple):
+                    if len(args) > 0:
+                        raise TypeError('arrays cannot have multiple types')
+                    return cls.Types.array(recurse(subtype, metadata=metadata))
+
+                elif origin_type is dict:
+                    return cls.Types.object_()
+
+            elif is_typeddict(type_):
+                content = {
+                    name: recurse(subtype)
+                    for name, subtype in get_type_hints(
+                        type_, include_extras=True
+                    ).items()
+                }
+                return cls.Types.object_(content)
+
+            elif type_ in cls._TYPES_FACTORIES.keys():
+                factory = cls._TYPES_FACTORIES[type_]
+                return factory(**metadata)
+
+            raise TypeError(f'unhandled type: {type_}')
+
+        return recurse(hint)
+
+    @classmethod
+    def from_init(cls, class_: type, *, ignore_keys: set[str] | None = None) -> dict:
+        ignore_keys = ignore_keys or set()
+        init_fn = getattr(class_, '__init__')
+
+        hints: dict[str, type] = {
+            param: type_
+            for param, type_ in get_type_hints(init_fn, include_extras=True).items()
+            if param not in ignore_keys
+        }
+
+        return {param: cls.scan_hint(hint) for param, hint in hints.items()}
 
 
 class Event:
+    _DEFAULT_PAYLOAD_IGNORE_KEYS = {
+        'self',
+        'return',
+        'tenant_uuid',
+        'user_uuid',
+        'user_uuids',
+    }
+
     def __init__(self, class_: type):
         self.class_ = class_
         sig = inspect.signature(getattr(class_, '__init__'))
@@ -125,7 +208,7 @@ class Event:
             headers['tenant_uuid'] = {'$ref': '#/components/schemas/tenant_uuid'}
             required.append('tenant_uuid')
 
-        if 'user_uuid' in self._keys:
+        if any([key in self._keys for key in ('user_uuid', 'user_uuids')]):
             headers['user_uuid:{uuid}'] = {
                 '$ref': '#/components/schemas/user_uuid:{uuid}'
             }
@@ -134,28 +217,8 @@ class Event:
         return {'type': 'object', 'properties': headers, 'required': required}
 
     def generate_payload(self) -> dict:
-        content = {}
-        keys_ignore_list = ('tenant_uuid', 'user_uuid', 'self')
-        content_keys = [key for key in self._keys if key not in keys_ignore_list]
-
-        for key in content_keys:
-            if key.endswith('uuid'):
-                content[key] = AsyncAPITypes.uuid()
-            elif key.endswith('uuids'):
-                content[key] = AsyncAPITypes.uuid(many=True)
-            elif key.endswith(('id', 'number')):
-                content[key] = AsyncAPITypes.integer()
-            elif key.startswith('is_'):
-                content[key] = AsyncAPITypes.boolean()
-            elif key.endswith('_at'):
-                content[key] = AsyncAPITypes.datetime()
-            elif key.endswith(('_data', '_info', '_schema')):
-                content[key] = AsyncAPITypes.object_()
-            else:
-                content[key] = AsyncAPITypes.string()
-
-        return AsyncAPITypes.object_(
-            dict(data=AsyncAPITypes.object_(content)),
+        return AsyncAPITypes.from_init(
+            self.class_, ignore_keys=self._DEFAULT_PAYLOAD_IGNORE_KEYS
         )
 
     def generate_parameters(self) -> dict:

--- a/xivo_bus/resources/adhoc_conference/event.py
+++ b/xivo_bus/resources/adhoc_conference/event.py
@@ -1,10 +1,8 @@
 # Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class AdhocConferenceCreatedEvent(UserEvent):
@@ -15,8 +13,8 @@ class AdhocConferenceCreatedEvent(UserEvent):
     def __init__(
         self,
         conference_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'conference_id': conference_id}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -30,8 +28,8 @@ class AdhocConferenceDeletedEvent(UserEvent):
     def __init__(
         self,
         conference_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'conference_id': conference_id}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -46,8 +44,8 @@ class AdhocConferenceParticipantJoinedEvent(UserEvent):
         self,
         conference_id: int,
         call_id: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'conference_id': conference_id, 'call_id': call_id}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -62,8 +60,8 @@ class AdhocConferenceParticipantLeftEvent(UserEvent):
         self,
         conference_id: int,
         call_id: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'conference_id': conference_id, 'call_id': call_id}
         super().__init__(content, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/adhoc_conference/event.py
+++ b/xivo_bus/resources/adhoc_conference/event.py
@@ -1,5 +1,7 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import UserEvent
 
@@ -9,7 +11,12 @@ class AdhocConferenceCreatedEvent(UserEvent):
     routing_key_fmt = 'conferences.users.{user_uuid}.adhoc.created'
     service = 'calld'
 
-    def __init__(self, conference_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        conference_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'conference_id': conference_id}
         super().__init__(content, tenant_uuid, user_uuid)
 
@@ -19,7 +26,12 @@ class AdhocConferenceDeletedEvent(UserEvent):
     routing_key_fmt = 'conferences.users.{user_uuid}.adhoc.deleted'
     service = 'calld'
 
-    def __init__(self, conference_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        conference_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'conference_id': conference_id}
         super().__init__(content, tenant_uuid, user_uuid)
 
@@ -30,7 +42,11 @@ class AdhocConferenceParticipantJoinedEvent(UserEvent):
     service = 'calld'
 
     def __init__(
-        self, conference_id: int, call_id: str, tenant_uuid: str, user_uuid: str
+        self,
+        conference_id: int,
+        call_id: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'conference_id': conference_id, 'call_id': call_id}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -42,7 +58,11 @@ class AdhocConferenceParticipantLeftEvent(UserEvent):
     service = 'calld'
 
     def __init__(
-        self, conference_id: int, call_id: str, tenant_uuid: str, user_uuid: str
+        self,
+        conference_id: int,
+        call_id: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'conference_id': conference_id, 'call_id': call_id}
         super().__init__(content, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/adhoc_conference/event.py
+++ b/xivo_bus/resources/adhoc_conference/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import UserEvent
+from ..common.event import UserEvent
+from ..common.types import Format
 
 
 class AdhocConferenceCreatedEvent(UserEvent):
@@ -14,8 +15,8 @@ class AdhocConferenceCreatedEvent(UserEvent):
     def __init__(
         self,
         conference_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'conference_id': conference_id}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -29,8 +30,8 @@ class AdhocConferenceDeletedEvent(UserEvent):
     def __init__(
         self,
         conference_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'conference_id': conference_id}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -45,8 +46,8 @@ class AdhocConferenceParticipantJoinedEvent(UserEvent):
         self,
         conference_id: int,
         call_id: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'conference_id': conference_id, 'call_id': call_id}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -61,8 +62,8 @@ class AdhocConferenceParticipantLeftEvent(UserEvent):
         self,
         conference_id: int,
         call_id: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'conference_id': conference_id, 'call_id': call_id}
         super().__init__(content, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/agent/event.py
+++ b/xivo_bus/resources/agent/event.py
@@ -1,9 +1,11 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from xivo_bus.resources.common.event import MultiUserEvent, TenantEvent
+from typing import Annotated
+
+from ..common.event import MultiUserEvent, TenantEvent
 
 
 class AgentCreatedEvent(TenantEvent):
@@ -13,7 +15,7 @@ class AgentCreatedEvent(TenantEvent):
     name = 'agent_created'
     routing_key_fmt = 'config.agent.created'
 
-    def __init__(self, agent_id: int, tenant_uuid: str):
+    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -25,7 +27,7 @@ class AgentDeletedEvent(TenantEvent):
     name = 'agent_deleted'
     routing_key_fmt = 'config.agent.deleted'
 
-    def __init__(self, agent_id: int, tenant_uuid: str):
+    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -37,7 +39,7 @@ class AgentEditedEvent(TenantEvent):
     name = 'agent_edited'
     routing_key_fmt = 'config.agent.edited'
 
-    def __init__(self, agent_id: int, tenant_uuid: str):
+    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -56,8 +58,8 @@ class AgentPausedEvent(MultiUserEvent):
         agent_number: str,
         queue: str,
         reason: str,
-        tenant_uuid: str,
-        user_uuids: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuids: Annotated[list[str], {'format': 'uuid'}],
     ):
         content = {
             'agent_id': agent_id,
@@ -83,8 +85,8 @@ class AgentUnpausedEvent(MultiUserEvent):
         agent_number: str,
         queue: str,
         reason: str,
-        tenant_uuid: str,
-        user_uuids: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuids: Annotated[list[str], {'format': 'uuid'}],
     ):
         content = {
             'agent_id': agent_id,
@@ -105,7 +107,11 @@ class AgentStatusUpdatedEvent(MultiUserEvent):
     required_acl_fmt = 'events.statuses.agents'
 
     def __init__(
-        self, agent_id: int, status: str, tenant_uuid: str, user_uuids: list[str]
+        self,
+        agent_id: int,
+        status: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuids: Annotated[list[str], {'format': 'uuid'}],
     ):
         content = {'agent_id': int(agent_id), 'status': status}
         super().__init__(content, tenant_uuid, user_uuids)

--- a/xivo_bus/resources/agent/event.py
+++ b/xivo_bus/resources/agent/event.py
@@ -3,10 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
 from ..common.event import MultiUserEvent, TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class AgentCreatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class AgentCreatedEvent(TenantEvent):
     name = 'agent_created'
     routing_key_fmt = 'config.agent.created'
 
-    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, agent_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -28,7 +26,7 @@ class AgentDeletedEvent(TenantEvent):
     name = 'agent_deleted'
     routing_key_fmt = 'config.agent.deleted'
 
-    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, agent_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -40,7 +38,7 @@ class AgentEditedEvent(TenantEvent):
     name = 'agent_edited'
     routing_key_fmt = 'config.agent.edited'
 
-    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, agent_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -59,8 +57,8 @@ class AgentPausedEvent(MultiUserEvent):
         agent_number: str,
         queue: str,
         reason: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuids: Annotated[list[str], Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuids: list[UUIDStr],
     ):
         content = {
             'agent_id': agent_id,
@@ -86,8 +84,8 @@ class AgentUnpausedEvent(MultiUserEvent):
         agent_number: str,
         queue: str,
         reason: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuids: Annotated[list[str], Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuids: list[UUIDStr],
     ):
         content = {
             'agent_id': agent_id,
@@ -111,8 +109,8 @@ class AgentStatusUpdatedEvent(MultiUserEvent):
         self,
         agent_id: int,
         status: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuids: Annotated[list[str], Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuids: list[UUIDStr],
     ):
         content = {'agent_id': int(agent_id), 'status': status}
         super().__init__(content, tenant_uuid, user_uuids)

--- a/xivo_bus/resources/agent/event.py
+++ b/xivo_bus/resources/agent/event.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from ..common.event import MultiUserEvent, TenantEvent
+from ..common.types import Format
 
 
 class AgentCreatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class AgentCreatedEvent(TenantEvent):
     name = 'agent_created'
     routing_key_fmt = 'config.agent.created'
 
-    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -27,7 +28,7 @@ class AgentDeletedEvent(TenantEvent):
     name = 'agent_deleted'
     routing_key_fmt = 'config.agent.deleted'
 
-    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -39,7 +40,7 @@ class AgentEditedEvent(TenantEvent):
     name = 'agent_edited'
     routing_key_fmt = 'config.agent.edited'
 
-    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, agent_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(agent_id)}
         super().__init__(content, tenant_uuid)
 
@@ -58,8 +59,8 @@ class AgentPausedEvent(MultiUserEvent):
         agent_number: str,
         queue: str,
         reason: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuids: Annotated[list[str], {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuids: Annotated[list[str], Format('uuid')],
     ):
         content = {
             'agent_id': agent_id,
@@ -85,8 +86,8 @@ class AgentUnpausedEvent(MultiUserEvent):
         agent_number: str,
         queue: str,
         reason: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuids: Annotated[list[str], {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuids: Annotated[list[str], Format('uuid')],
     ):
         content = {
             'agent_id': agent_id,
@@ -110,8 +111,8 @@ class AgentStatusUpdatedEvent(MultiUserEvent):
         self,
         agent_id: int,
         status: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuids: Annotated[list[str], {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuids: Annotated[list[str], Format('uuid')],
     ):
         content = {'agent_id': int(agent_id), 'status': status}
         super().__init__(content, tenant_uuid, user_uuids)

--- a/xivo_bus/resources/agent_skill/event.py
+++ b/xivo_bus/resources/agent_skill/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class AgentSkillAssociatedEvent(TenantEvent):
     name = 'agent_skill_associated'
     routing_key_fmt = 'config.agents.skills.updated'
 
-    def __init__(self, agent_id: int, skill_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        agent_id: int,
+        skill_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'agent_id': agent_id,
             'skill_id': skill_id,
@@ -22,7 +29,12 @@ class AgentSkillDissociatedEvent(TenantEvent):
     name = 'agent_skill_dissociated'
     routing_key_fmt = 'config.agents.skills.deleted'
 
-    def __init__(self, agent_id: int, skill_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        agent_id: int,
+        skill_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'agent_id': agent_id,
             'skill_id': skill_id,

--- a/xivo_bus/resources/agent_skill/event.py
+++ b/xivo_bus/resources/agent_skill/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class AgentSkillAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class AgentSkillAssociatedEvent(TenantEvent):
         self,
         agent_id: int,
         skill_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'agent_id': agent_id,
@@ -34,7 +32,7 @@ class AgentSkillDissociatedEvent(TenantEvent):
         self,
         agent_id: int,
         skill_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'agent_id': agent_id,

--- a/xivo_bus/resources/agent_skill/event.py
+++ b/xivo_bus/resources/agent_skill/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class AgentSkillAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class AgentSkillAssociatedEvent(TenantEvent):
         self,
         agent_id: int,
         skill_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'agent_id': agent_id,
@@ -33,7 +34,7 @@ class AgentSkillDissociatedEvent(TenantEvent):
         self,
         agent_id: int,
         skill_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'agent_id': agent_id,

--- a/xivo_bus/resources/application/event.py
+++ b/xivo_bus/resources/application/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -11,7 +13,11 @@ class ApplicationCreatedEvent(TenantEvent):
     name = 'application_created'
     routing_key_fmt = 'config.applications.created'
 
-    def __init__(self, application: ApplicationDict, tenant_uuid: str):
+    def __init__(
+        self,
+        application: ApplicationDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(application, tenant_uuid)
 
 
@@ -20,7 +26,11 @@ class ApplicationDeletedEvent(TenantEvent):
     name = 'application_deleted'
     routing_key_fmt = 'config.applications.deleted'
 
-    def __init__(self, application: ApplicationDict, tenant_uuid: str):
+    def __init__(
+        self,
+        application: ApplicationDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(application, tenant_uuid)
 
 
@@ -29,5 +39,9 @@ class ApplicationEditedEvent(TenantEvent):
     name = 'application_edited'
     routing_key_fmt = 'config.applications.edited'
 
-    def __init__(self, application: ApplicationDict, tenant_uuid: str):
+    def __init__(
+        self,
+        application: ApplicationDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(application, tenant_uuid)

--- a/xivo_bus/resources/application/event.py
+++ b/xivo_bus/resources/application/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import ApplicationDict
 
 
@@ -16,7 +14,7 @@ class ApplicationCreatedEvent(TenantEvent):
     def __init__(
         self,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(application, tenant_uuid)
 
@@ -29,7 +27,7 @@ class ApplicationDeletedEvent(TenantEvent):
     def __init__(
         self,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(application, tenant_uuid)
 
@@ -42,6 +40,6 @@ class ApplicationEditedEvent(TenantEvent):
     def __init__(
         self,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(application, tenant_uuid)

--- a/xivo_bus/resources/application/event.py
+++ b/xivo_bus/resources/application/event.py
@@ -3,8 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
-
+from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import ApplicationDict
 
 
@@ -16,7 +16,7 @@ class ApplicationCreatedEvent(TenantEvent):
     def __init__(
         self,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(application, tenant_uuid)
 
@@ -29,7 +29,7 @@ class ApplicationDeletedEvent(TenantEvent):
     def __init__(
         self,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(application, tenant_uuid)
 
@@ -42,6 +42,6 @@ class ApplicationEditedEvent(TenantEvent):
     def __init__(
         self,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(application, tenant_uuid)

--- a/xivo_bus/resources/application/types.py
+++ b/xivo_bus/resources/application/types.py
@@ -3,14 +3,14 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ApplicationDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     name: str
     destination: str | None
     destination_options: dict[str, str]

--- a/xivo_bus/resources/application/types.py
+++ b/xivo_bus/resources/application/types.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class ApplicationDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     name: str
     destination: str | None
     destination_options: dict[str, str]

--- a/xivo_bus/resources/application/types.py
+++ b/xivo_bus/resources/application/types.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class ApplicationDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     name: str
     destination: str | None
     destination_options: dict[str, str]

--- a/xivo_bus/resources/auth/events.py
+++ b/xivo_bus/resources/auth/events.py
@@ -3,8 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent, UserEvent
-
+from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 from .types import TenantDict
 
 
@@ -14,7 +14,7 @@ class TenantCreatedEvent(TenantEvent):
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.created'
 
     def __init__(
-        self, tenant_data: TenantDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, tenant_data: TenantDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(tenant_data, tenant_uuid)
 
@@ -24,7 +24,7 @@ class TenantUpdatedEvent(TenantEvent):
     name = 'auth_tenant_updated'
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.updated'
 
-    def __init__(self, name: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, name: str, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'uuid': tenant_uuid, 'name': name}
         super().__init__(content, tenant_uuid)
 
@@ -34,7 +34,7 @@ class TenantDeletedEvent(TenantEvent):
     name = 'auth_tenant_deleted'
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.deleted'
 
-    def __init__(self, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'uuid': tenant_uuid}
         super().__init__(content, tenant_uuid)
 
@@ -47,8 +47,8 @@ class UserExternalAuthAddedEvent(UserEvent):
     def __init__(
         self,
         external_auth_name: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -62,8 +62,8 @@ class UserExternalAuthAuthorizedEvent(UserEvent):
     def __init__(
         self,
         external_auth_name: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -77,8 +77,8 @@ class UserExternalAuthDeletedEvent(UserEvent):
     def __init__(
         self,
         external_auth_name: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -93,8 +93,8 @@ class RefreshTokenCreatedEvent(UserEvent):
         self,
         client_id: str,
         is_mobile: bool,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'client_id': client_id,
@@ -114,8 +114,8 @@ class RefreshTokenDeletedEvent(UserEvent):
         self,
         client_id: str,
         is_mobile: bool,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'client_id': client_id,
@@ -133,10 +133,10 @@ class SessionCreatedEvent(UserEvent):
 
     def __init__(
         self,
-        session_uuid: Annotated[str, {'format': 'uuid'}],
+        session_uuid: Annotated[str, Format('uuid')],
         is_mobile: bool,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'uuid': session_uuid,
@@ -155,9 +155,9 @@ class SessionDeletedEvent(UserEvent):
 
     def __init__(
         self,
-        session_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        session_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'uuid': session_uuid,
@@ -175,9 +175,9 @@ class SessionExpireSoonEvent(UserEvent):
 
     def __init__(
         self,
-        session_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        session_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'uuid': session_uuid,

--- a/xivo_bus/resources/auth/events.py
+++ b/xivo_bus/resources/auth/events.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import TenantDict
 
 
@@ -13,9 +11,7 @@ class TenantCreatedEvent(TenantEvent):
     name = 'auth_tenant_added'
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.created'
 
-    def __init__(
-        self, tenant_data: TenantDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, tenant_data: TenantDict, tenant_uuid: UUIDStr):
         super().__init__(tenant_data, tenant_uuid)
 
 
@@ -24,7 +20,7 @@ class TenantUpdatedEvent(TenantEvent):
     name = 'auth_tenant_updated'
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.updated'
 
-    def __init__(self, name: str, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, name: str, tenant_uuid: UUIDStr):
         content = {'uuid': tenant_uuid, 'name': name}
         super().__init__(content, tenant_uuid)
 
@@ -34,7 +30,7 @@ class TenantDeletedEvent(TenantEvent):
     name = 'auth_tenant_deleted'
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.deleted'
 
-    def __init__(self, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, tenant_uuid: UUIDStr):
         content = {'uuid': tenant_uuid}
         super().__init__(content, tenant_uuid)
 
@@ -47,8 +43,8 @@ class UserExternalAuthAddedEvent(UserEvent):
     def __init__(
         self,
         external_auth_name: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -62,8 +58,8 @@ class UserExternalAuthAuthorizedEvent(UserEvent):
     def __init__(
         self,
         external_auth_name: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -77,8 +73,8 @@ class UserExternalAuthDeletedEvent(UserEvent):
     def __init__(
         self,
         external_auth_name: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
@@ -93,8 +89,8 @@ class RefreshTokenCreatedEvent(UserEvent):
         self,
         client_id: str,
         is_mobile: bool,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'client_id': client_id,
@@ -114,8 +110,8 @@ class RefreshTokenDeletedEvent(UserEvent):
         self,
         client_id: str,
         is_mobile: bool,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'client_id': client_id,
@@ -133,10 +129,10 @@ class SessionCreatedEvent(UserEvent):
 
     def __init__(
         self,
-        session_uuid: Annotated[str, Format('uuid')],
+        session_uuid: UUIDStr,
         is_mobile: bool,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'uuid': session_uuid,
@@ -155,9 +151,9 @@ class SessionDeletedEvent(UserEvent):
 
     def __init__(
         self,
-        session_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        session_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'uuid': session_uuid,
@@ -175,9 +171,9 @@ class SessionExpireSoonEvent(UserEvent):
 
     def __init__(
         self,
-        session_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        session_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'uuid': session_uuid,

--- a/xivo_bus/resources/auth/events.py
+++ b/xivo_bus/resources/auth/events.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent, UserEvent
 
@@ -11,7 +13,9 @@ class TenantCreatedEvent(TenantEvent):
     name = 'auth_tenant_added'
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.created'
 
-    def __init__(self, tenant_data: TenantDict, tenant_uuid: str):
+    def __init__(
+        self, tenant_data: TenantDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(tenant_data, tenant_uuid)
 
 
@@ -20,7 +24,7 @@ class TenantUpdatedEvent(TenantEvent):
     name = 'auth_tenant_updated'
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.updated'
 
-    def __init__(self, name: str, tenant_uuid: str):
+    def __init__(self, name: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'uuid': tenant_uuid, 'name': name}
         super().__init__(content, tenant_uuid)
 
@@ -30,7 +34,7 @@ class TenantDeletedEvent(TenantEvent):
     name = 'auth_tenant_deleted'
     routing_key_fmt = 'auth.tenants.{tenant_uuid}.deleted'
 
-    def __init__(self, tenant_uuid: str):
+    def __init__(self, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'uuid': tenant_uuid}
         super().__init__(content, tenant_uuid)
 
@@ -40,7 +44,12 @@ class UserExternalAuthAddedEvent(UserEvent):
     name = 'auth_user_external_auth_added'
     routing_key_fmt = 'auth.users.{user_uuid}.external.{external_auth_name}.created'
 
-    def __init__(self, external_auth_name: str, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        external_auth_name: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
 
@@ -50,7 +59,12 @@ class UserExternalAuthAuthorizedEvent(UserEvent):
     name = 'auth_user_external_auth_authorized'
     routing_key_fmt = 'auth.users.{user_uuid}.external.{external_auth_name}.authorized'
 
-    def __init__(self, external_auth_name: str, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        external_auth_name: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
 
@@ -60,7 +74,12 @@ class UserExternalAuthDeletedEvent(UserEvent):
     name = 'auth_user_external_auth_deleted'
     routing_key_fmt = 'auth.users.{user_uuid}.external.{external_auth_name}.deleted'
 
-    def __init__(self, external_auth_name: str, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        external_auth_name: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'user_uuid': user_uuid, 'external_auth_name': external_auth_name}
         super().__init__(content, tenant_uuid, user_uuid)
 
@@ -71,7 +90,11 @@ class RefreshTokenCreatedEvent(UserEvent):
     routing_key_fmt = 'auth.users.{user_uuid}.tokens.{client_id}.created'
 
     def __init__(
-        self, client_id: str, is_mobile: bool, tenant_uuid: str, user_uuid: str
+        self,
+        client_id: str,
+        is_mobile: bool,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'client_id': client_id,
@@ -88,7 +111,11 @@ class RefreshTokenDeletedEvent(UserEvent):
     routing_key_fmt = 'auth.users.{user_uuid}.tokens.{client_id}.deleted'
 
     def __init__(
-        self, client_id: str, is_mobile: bool, tenant_uuid: str, user_uuid: str
+        self,
+        client_id: str,
+        is_mobile: bool,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'client_id': client_id,
@@ -105,7 +132,11 @@ class SessionCreatedEvent(UserEvent):
     routing_key_fmt = 'auth.sessions.{session_uuid}.created'
 
     def __init__(
-        self, session_uuid: str, is_mobile: bool, tenant_uuid: str, user_uuid: str
+        self,
+        session_uuid: Annotated[str, {'format': 'uuid'}],
+        is_mobile: bool,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'uuid': session_uuid,
@@ -122,7 +153,12 @@ class SessionDeletedEvent(UserEvent):
     name = 'auth_session_deleted'
     routing_key_fmt = 'auth.sessions.{session_uuid}.deleted'
 
-    def __init__(self, session_uuid: str, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        session_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'uuid': session_uuid,
             'user_uuid': user_uuid,
@@ -137,7 +173,12 @@ class SessionExpireSoonEvent(UserEvent):
     name = 'auth_session_expire_soon'
     routing_key_fmt = 'auth.users.{user_uuid}.sessions.{session_uuid}.expire_soon'
 
-    def __init__(self, session_uuid: str, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        session_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'uuid': session_uuid,
             'user_uuid': user_uuid,

--- a/xivo_bus/resources/auth/types.py
+++ b/xivo_bus/resources/auth/types.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class TenantDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     name: str
     slug: str
     domain_names: list[str]

--- a/xivo_bus/resources/auth/types.py
+++ b/xivo_bus/resources/auth/types.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class TenantDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     name: str
     slug: str
     domain_names: list[str]

--- a/xivo_bus/resources/auth/types.py
+++ b/xivo_bus/resources/auth/types.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class TenantDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     name: str
     slug: str
     domain_names: list[str]

--- a/xivo_bus/resources/call_filter/event.py
+++ b/xivo_bus/resources/call_filter/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class CallFilterCreatedEvent(TenantEvent):
@@ -12,9 +10,7 @@ class CallFilterCreatedEvent(TenantEvent):
     name = 'call_filter_created'
     routing_key_fmt = 'config.callfilter.created'
 
-    def __init__(
-        self, call_filter_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_filter_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
 
@@ -24,9 +20,7 @@ class CallFilterDeletedEvent(TenantEvent):
     name = 'call_filter_deleted'
     routing_key_fmt = 'config.callfilter.deleted'
 
-    def __init__(
-        self, call_filter_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_filter_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
 
@@ -36,9 +30,7 @@ class CallFilterEditedEvent(TenantEvent):
     name = 'call_filter_edited'
     routing_key_fmt = 'config.callfilter.edited'
 
-    def __init__(
-        self, call_filter_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_filter_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
 
@@ -48,8 +40,6 @@ class CallFilterFallbackEditedEvent(TenantEvent):
     name = 'call_filter_fallback_edited'
     routing_key_fmt = 'config.callfilters.fallbacks.edited'
 
-    def __init__(
-        self, call_filter_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_filter_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_filter/event.py
+++ b/xivo_bus/resources/call_filter/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class CallFilterCreatedEvent(TenantEvent):
@@ -12,7 +13,7 @@ class CallFilterCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.callfilter.created'
 
     def __init__(
-        self, call_filter_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_filter_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
@@ -24,7 +25,7 @@ class CallFilterDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.callfilter.deleted'
 
     def __init__(
-        self, call_filter_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_filter_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
@@ -36,7 +37,7 @@ class CallFilterEditedEvent(TenantEvent):
     routing_key_fmt = 'config.callfilter.edited'
 
     def __init__(
-        self, call_filter_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_filter_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
@@ -48,7 +49,7 @@ class CallFilterFallbackEditedEvent(TenantEvent):
     routing_key_fmt = 'config.callfilters.fallbacks.edited'
 
     def __init__(
-        self, call_filter_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_filter_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_filter/event.py
+++ b/xivo_bus/resources/call_filter/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class CallFilterCreatedEvent(TenantEvent):
     name = 'call_filter_created'
     routing_key_fmt = 'config.callfilter.created'
 
-    def __init__(self, call_filter_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_filter_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +23,9 @@ class CallFilterDeletedEvent(TenantEvent):
     name = 'call_filter_deleted'
     routing_key_fmt = 'config.callfilter.deleted'
 
-    def __init__(self, call_filter_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_filter_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,7 +35,9 @@ class CallFilterEditedEvent(TenantEvent):
     name = 'call_filter_edited'
     routing_key_fmt = 'config.callfilter.edited'
 
-    def __init__(self, call_filter_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_filter_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)
 
@@ -39,6 +47,8 @@ class CallFilterFallbackEditedEvent(TenantEvent):
     name = 'call_filter_fallback_edited'
     routing_key_fmt = 'config.callfilters.fallbacks.edited'
 
-    def __init__(self, call_filter_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_filter_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_filter_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_filter_user/event.py
+++ b/xivo_bus/resources/call_filter_user/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class CallFilterRecipientUsersAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class CallFilterRecipientUsersAssociatedEvent(TenantEvent):
         self,
         call_filter_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_filter_id': call_filter_id,
@@ -33,7 +34,7 @@ class CallFilterSurrogateUsersAssociatedEvent(TenantEvent):
         self,
         call_filter_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_filter_id': call_filter_id,

--- a/xivo_bus/resources/call_filter_user/event.py
+++ b/xivo_bus/resources/call_filter_user/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class CallFilterRecipientUsersAssociatedEvent(TenantEvent):
     name = 'call_filter_recipient_users_associated'
     routing_key_fmt = 'config.callfilters.recipients.users.updated'
 
-    def __init__(self, call_filter_id: int, users: list[str], tenant_uuid: str):
+    def __init__(
+        self,
+        call_filter_id: int,
+        users: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'call_filter_id': call_filter_id,
             'user_uuids': users,
@@ -22,7 +29,12 @@ class CallFilterSurrogateUsersAssociatedEvent(TenantEvent):
     name = 'call_filter_surrogate_users_associated'
     routing_key_fmt = 'config.callfilters.surrogates.users.updated'
 
-    def __init__(self, call_filter_id: int, users: list[str], tenant_uuid: str):
+    def __init__(
+        self,
+        call_filter_id: int,
+        users: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'call_filter_id': call_filter_id,
             'user_uuids': users,

--- a/xivo_bus/resources/call_filter_user/event.py
+++ b/xivo_bus/resources/call_filter_user/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class CallFilterRecipientUsersAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class CallFilterRecipientUsersAssociatedEvent(TenantEvent):
         self,
         call_filter_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'call_filter_id': call_filter_id,
@@ -34,7 +32,7 @@ class CallFilterSurrogateUsersAssociatedEvent(TenantEvent):
         self,
         call_filter_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'call_filter_id': call_filter_id,

--- a/xivo_bus/resources/call_logd/events.py
+++ b/xivo_bus/resources/call_logd/events.py
@@ -1,10 +1,8 @@
 # Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import CallLogExportDataDict
 
 
@@ -16,7 +14,7 @@ class CallLogExportCreatedEvent(TenantEvent):
     def __init__(
         self,
         export_data: CallLogExportDataDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(export_data, tenant_uuid)
 
@@ -29,7 +27,7 @@ class CallLogExportUpdatedEvent(TenantEvent):
     def __init__(
         self,
         export_data: CallLogExportDataDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(export_data, tenant_uuid)
 
@@ -42,6 +40,6 @@ class CallLogRetentionUpdatedEvent(TenantEvent):
     def __init__(
         self,
         retention_data: CallLogExportDataDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(retention_data, tenant_uuid)

--- a/xivo_bus/resources/call_logd/events.py
+++ b/xivo_bus/resources/call_logd/events.py
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -11,7 +13,11 @@ class CallLogExportCreatedEvent(TenantEvent):
     name = 'call_logd_export_created'
     routing_key_fmt = 'call_logd.export.created'
 
-    def __init__(self, export_data: CallLogExportDataDict, tenant_uuid: str):
+    def __init__(
+        self,
+        export_data: CallLogExportDataDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(export_data, tenant_uuid)
 
 
@@ -20,7 +26,11 @@ class CallLogExportUpdatedEvent(TenantEvent):
     name = 'call_logd_export_updated'
     routing_key_fmt = 'call_logd.export.updated'
 
-    def __init__(self, export_data: CallLogExportDataDict, tenant_uuid: str):
+    def __init__(
+        self,
+        export_data: CallLogExportDataDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(export_data, tenant_uuid)
 
 
@@ -29,5 +39,9 @@ class CallLogRetentionUpdatedEvent(TenantEvent):
     name = 'call_logd_retention_updated'
     routing_key_fmt = 'call_logd.retention.updated'
 
-    def __init__(self, retention_data: CallLogExportDataDict, tenant_uuid: str):
+    def __init__(
+        self,
+        retention_data: CallLogExportDataDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(retention_data, tenant_uuid)

--- a/xivo_bus/resources/call_logd/events.py
+++ b/xivo_bus/resources/call_logd/events.py
@@ -3,8 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
-
+from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import CallLogExportDataDict
 
 
@@ -16,7 +16,7 @@ class CallLogExportCreatedEvent(TenantEvent):
     def __init__(
         self,
         export_data: CallLogExportDataDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(export_data, tenant_uuid)
 
@@ -29,7 +29,7 @@ class CallLogExportUpdatedEvent(TenantEvent):
     def __init__(
         self,
         export_data: CallLogExportDataDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(export_data, tenant_uuid)
 
@@ -42,6 +42,6 @@ class CallLogRetentionUpdatedEvent(TenantEvent):
     def __init__(
         self,
         retention_data: CallLogExportDataDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(retention_data, tenant_uuid)

--- a/xivo_bus/resources/call_logd/types.py
+++ b/xivo_bus/resources/call_logd/types.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class CallLogExportDataDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    user_uuid: Annotated[str, {'format': 'uuid'}]
-    requested_at: Annotated[str, {'format': 'date-time'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
+    user_uuid: Annotated[str, Format('uuid')]
+    requested_at: Annotated[str, Format('date-time')]
     filename: str
     status: str

--- a/xivo_bus/resources/call_logd/types.py
+++ b/xivo_bus/resources/call_logd/types.py
@@ -3,15 +3,15 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import DateTimeStr, UUIDStr
 
 
 class CallLogExportDataDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
-    user_uuid: Annotated[str, Format('uuid')]
-    requested_at: Annotated[str, Format('date-time')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
+    user_uuid: UUIDStr
+    requested_at: DateTimeStr
     filename: str
     status: str

--- a/xivo_bus/resources/call_logd/types.py
+++ b/xivo_bus/resources/call_logd/types.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class CallLogExportDataDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
-    user_uuid: str
-    requested_at: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    user_uuid: Annotated[str, {'format': 'uuid'}]
+    requested_at: Annotated[str, {'format': 'date-time'}]
     filename: str
     status: str

--- a/xivo_bus/resources/call_logs/events.py
+++ b/xivo_bus/resources/call_logs/events.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent, UserEvent
 
@@ -11,7 +13,9 @@ class CallLogCreatedEvent(TenantEvent):
     name = 'call_log_created'
     routing_key_fmt = 'call_log.created'
 
-    def __init__(self, cdr_data: CDRDataDict, tenant_uuid: str):
+    def __init__(
+        self, cdr_data: CDRDataDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(cdr_data, tenant_uuid)
 
 
@@ -20,5 +24,10 @@ class CallLogUserCreatedEvent(UserEvent):
     name = 'call_log_user_created'
     routing_key_fmt = 'call_log.user.{user_uuid}.created'
 
-    def __init__(self, cdr_data: CDRDataDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        cdr_data: CDRDataDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(cdr_data, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/call_logs/events.py
+++ b/xivo_bus/resources/call_logs/events.py
@@ -3,8 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent, UserEvent
-
+from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 from .types import CDRDataDict
 
 
@@ -14,7 +14,7 @@ class CallLogCreatedEvent(TenantEvent):
     routing_key_fmt = 'call_log.created'
 
     def __init__(
-        self, cdr_data: CDRDataDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, cdr_data: CDRDataDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(cdr_data, tenant_uuid)
 
@@ -27,7 +27,7 @@ class CallLogUserCreatedEvent(UserEvent):
     def __init__(
         self,
         cdr_data: CDRDataDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(cdr_data, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/call_logs/events.py
+++ b/xivo_bus/resources/call_logs/events.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import CDRDataDict
 
 
@@ -13,9 +11,7 @@ class CallLogCreatedEvent(TenantEvent):
     name = 'call_log_created'
     routing_key_fmt = 'call_log.created'
 
-    def __init__(
-        self, cdr_data: CDRDataDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, cdr_data: CDRDataDict, tenant_uuid: UUIDStr):
         super().__init__(cdr_data, tenant_uuid)
 
 
@@ -27,7 +23,7 @@ class CallLogUserCreatedEvent(UserEvent):
     def __init__(
         self,
         cdr_data: CDRDataDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(cdr_data, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/call_logs/types.py
+++ b/xivo_bus/resources/call_logs/types.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class DestinationConferenceDict(TypedDict, total=False):
@@ -11,12 +11,12 @@ class DestinationConferenceDict(TypedDict, total=False):
 
 
 class DestinationMeetingDict(TypedDict, total=False):
-    meeting_uuid: str
+    meeting_uuid: Annotated[str, {'format': 'uuid'}]
     meeting_name: str
 
 
 class DestinationUserDict(TypedDict, total=False):
-    user_uuid: str
+    user_uuid: Annotated[str, {'format': 'uuid'}]
     user_name: str
 
 
@@ -32,7 +32,7 @@ class DestinationDetailsDict(TypedDict, total=False):
 
 
 class RecordingDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     start_time: str
     end_time: str
     deleted: bool
@@ -41,9 +41,9 @@ class RecordingDict(TypedDict, total=False):
 
 class CDRDataDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
-    start: str
-    end: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    start: Annotated[str, {'format': 'date-time'}]
+    end: Annotated[str, {'format': 'date-time'}]
     answered: bool
     duration: float
     call_drection: str
@@ -53,7 +53,7 @@ class CDRDataDict(TypedDict, total=False):
     destination_internal_extension: str
     destination_line_id: int
     destination_name: str
-    destination_user_uuid: str
+    destination_user_uuid: Annotated[str, {'format': 'uuid'}]
     requested_name: str
     requested_context: str
     requested_extension: str
@@ -65,6 +65,6 @@ class CDRDataDict(TypedDict, total=False):
     source_internal_extension: str
     source_line_id: int
     source_name: str
-    source_user_uuid: str
+    source_user_uuid: Annotated[str, {'format': 'uuid'}]
     tags: list[str]
     recordings: list[RecordingDict]

--- a/xivo_bus/resources/call_logs/types.py
+++ b/xivo_bus/resources/call_logs/types.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class DestinationConferenceDict(TypedDict, total=False):
     conference_id: int
 
 
 class DestinationMeetingDict(TypedDict, total=False):
-    meeting_uuid: Annotated[str, {'format': 'uuid'}]
+    meeting_uuid: Annotated[str, Format('uuid')]
     meeting_name: str
 
 
 class DestinationUserDict(TypedDict, total=False):
-    user_uuid: Annotated[str, {'format': 'uuid'}]
+    user_uuid: Annotated[str, Format('uuid')]
     user_name: str
 
 
@@ -32,7 +34,7 @@ class DestinationDetailsDict(TypedDict, total=False):
 
 
 class RecordingDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     start_time: str
     end_time: str
     deleted: bool
@@ -41,9 +43,9 @@ class RecordingDict(TypedDict, total=False):
 
 class CDRDataDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    start: Annotated[str, {'format': 'date-time'}]
-    end: Annotated[str, {'format': 'date-time'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
+    start: Annotated[str, Format('date-time')]
+    end: Annotated[str, Format('date-time')]
     answered: bool
     duration: float
     call_drection: str
@@ -53,7 +55,7 @@ class CDRDataDict(TypedDict, total=False):
     destination_internal_extension: str
     destination_line_id: int
     destination_name: str
-    destination_user_uuid: Annotated[str, {'format': 'uuid'}]
+    destination_user_uuid: Annotated[str, Format('uuid')]
     requested_name: str
     requested_context: str
     requested_extension: str
@@ -65,6 +67,6 @@ class CDRDataDict(TypedDict, total=False):
     source_internal_extension: str
     source_line_id: int
     source_name: str
-    source_user_uuid: Annotated[str, {'format': 'uuid'}]
+    source_user_uuid: Annotated[str, Format('uuid')]
     tags: list[str]
     recordings: list[RecordingDict]

--- a/xivo_bus/resources/call_logs/types.py
+++ b/xivo_bus/resources/call_logs/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import DateTimeStr, UUIDStr
 
 
 class DestinationConferenceDict(TypedDict, total=False):
@@ -13,12 +13,12 @@ class DestinationConferenceDict(TypedDict, total=False):
 
 
 class DestinationMeetingDict(TypedDict, total=False):
-    meeting_uuid: Annotated[str, Format('uuid')]
+    meeting_uuid: UUIDStr
     meeting_name: str
 
 
 class DestinationUserDict(TypedDict, total=False):
-    user_uuid: Annotated[str, Format('uuid')]
+    user_uuid: UUIDStr
     user_name: str
 
 
@@ -34,7 +34,7 @@ class DestinationDetailsDict(TypedDict, total=False):
 
 
 class RecordingDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     start_time: str
     end_time: str
     deleted: bool
@@ -43,9 +43,9 @@ class RecordingDict(TypedDict, total=False):
 
 class CDRDataDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
-    start: Annotated[str, Format('date-time')]
-    end: Annotated[str, Format('date-time')]
+    tenant_uuid: UUIDStr
+    start: DateTimeStr
+    end: DateTimeStr
     answered: bool
     duration: float
     call_drection: str
@@ -55,7 +55,7 @@ class CDRDataDict(TypedDict, total=False):
     destination_internal_extension: str
     destination_line_id: int
     destination_name: str
-    destination_user_uuid: Annotated[str, Format('uuid')]
+    destination_user_uuid: UUIDStr
     requested_name: str
     requested_context: str
     requested_extension: str
@@ -67,6 +67,6 @@ class CDRDataDict(TypedDict, total=False):
     source_internal_extension: str
     source_line_id: int
     source_name: str
-    source_user_uuid: Annotated[str, Format('uuid')]
+    source_user_uuid: UUIDStr
     tags: list[str]
     recordings: list[RecordingDict]

--- a/xivo_bus/resources/call_permission/event.py
+++ b/xivo_bus/resources/call_permission/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class CallPermissionCreatedEvent(TenantEvent):
@@ -12,9 +10,7 @@ class CallPermissionCreatedEvent(TenantEvent):
     name = 'call_permission_created'
     routing_key_fmt = 'config.callpermission.created'
 
-    def __init__(
-        self, call_permission_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_permission_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)
 
@@ -24,9 +20,7 @@ class CallPermissionDeletedEvent(TenantEvent):
     name = 'call_permission_deleted'
     routing_key_fmt = 'config.callpermission.deleted'
 
-    def __init__(
-        self, call_permission_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_permission_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)
 
@@ -36,8 +30,6 @@ class CallPermissionEditedEvent(TenantEvent):
     name = 'call_permission_edited'
     routing_key_fmt = 'config.callpermission.edited'
 
-    def __init__(
-        self, call_permission_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_permission_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_permission/event.py
+++ b/xivo_bus/resources/call_permission/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class CallPermissionCreatedEvent(TenantEvent):
     name = 'call_permission_created'
     routing_key_fmt = 'config.callpermission.created'
 
-    def __init__(self, call_permission_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_permission_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +23,9 @@ class CallPermissionDeletedEvent(TenantEvent):
     name = 'call_permission_deleted'
     routing_key_fmt = 'config.callpermission.deleted'
 
-    def __init__(self, call_permission_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_permission_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +35,8 @@ class CallPermissionEditedEvent(TenantEvent):
     name = 'call_permission_edited'
     routing_key_fmt = 'config.callpermission.edited'
 
-    def __init__(self, call_permission_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_permission_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_permission/event.py
+++ b/xivo_bus/resources/call_permission/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class CallPermissionCreatedEvent(TenantEvent):
@@ -12,7 +13,7 @@ class CallPermissionCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.callpermission.created'
 
     def __init__(
-        self, call_permission_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_permission_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)
@@ -24,7 +25,7 @@ class CallPermissionDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.callpermission.deleted'
 
     def __init__(
-        self, call_permission_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_permission_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)
@@ -36,7 +37,7 @@ class CallPermissionEditedEvent(TenantEvent):
     routing_key_fmt = 'config.callpermission.edited'
 
     def __init__(
-        self, call_permission_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_permission_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_permission_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_pickup/event.py
+++ b/xivo_bus/resources/call_pickup/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class CallPickupCreatedEvent(TenantEvent):
     name = 'call_pickup_created'
     routing_key_fmt = 'config.callpickup.created'
 
-    def __init__(self, call_pickup_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_pickup_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +23,9 @@ class CallPickupDeletedEvent(TenantEvent):
     name = 'call_pickup_deleted'
     routing_key_fmt = 'config.callpickup.deleted'
 
-    def __init__(self, call_pickup_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_pickup_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +35,8 @@ class CallPickupEditedEvent(TenantEvent):
     name = 'call_pickup_edited'
     routing_key_fmt = 'config.callpickup.edited'
 
-    def __init__(self, call_pickup_id: int, tenant_uuid: str):
+    def __init__(
+        self, call_pickup_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_pickup/event.py
+++ b/xivo_bus/resources/call_pickup/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class CallPickupCreatedEvent(TenantEvent):
@@ -12,9 +10,7 @@ class CallPickupCreatedEvent(TenantEvent):
     name = 'call_pickup_created'
     routing_key_fmt = 'config.callpickup.created'
 
-    def __init__(
-        self, call_pickup_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_pickup_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)
 
@@ -24,9 +20,7 @@ class CallPickupDeletedEvent(TenantEvent):
     name = 'call_pickup_deleted'
     routing_key_fmt = 'config.callpickup.deleted'
 
-    def __init__(
-        self, call_pickup_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_pickup_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)
 
@@ -36,8 +30,6 @@ class CallPickupEditedEvent(TenantEvent):
     name = 'call_pickup_edited'
     routing_key_fmt = 'config.callpickup.edited'
 
-    def __init__(
-        self, call_pickup_id: int, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, call_pickup_id: int, tenant_uuid: UUIDStr):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_pickup/event.py
+++ b/xivo_bus/resources/call_pickup/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class CallPickupCreatedEvent(TenantEvent):
@@ -12,7 +13,7 @@ class CallPickupCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.callpickup.created'
 
     def __init__(
-        self, call_pickup_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_pickup_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)
@@ -24,7 +25,7 @@ class CallPickupDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.callpickup.deleted'
 
     def __init__(
-        self, call_pickup_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_pickup_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)
@@ -36,7 +37,7 @@ class CallPickupEditedEvent(TenantEvent):
     routing_key_fmt = 'config.callpickup.edited'
 
     def __init__(
-        self, call_pickup_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, call_pickup_id: int, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         content = {'id': call_pickup_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/call_pickup_member/event.py
+++ b/xivo_bus/resources/call_pickup_member/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class CallPickupInterceptorUsersAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class CallPickupInterceptorUsersAssociatedEvent(TenantEvent):
         self,
         call_pickup_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_pickup_id': call_pickup_id,
@@ -33,7 +34,7 @@ class CallPickupTargetUsersAssociatedEvent(TenantEvent):
         self,
         call_pickup_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_pickup_id': call_pickup_id,
@@ -51,7 +52,7 @@ class CallPickupInterceptorGroupsAssociatedEvent(TenantEvent):
         self,
         call_pickup_id: int,
         group_ids: list[int],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_pickup_id': call_pickup_id,
@@ -69,7 +70,7 @@ class CallPickupTargetGroupsAssociatedEvent(TenantEvent):
         self,
         call_pickup_id: int,
         group_ids: list[int],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_pickup_id': call_pickup_id,

--- a/xivo_bus/resources/call_pickup_member/event.py
+++ b/xivo_bus/resources/call_pickup_member/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class CallPickupInterceptorUsersAssociatedEvent(TenantEvent):
     name = 'call_pickup_interceptor_users_associated'
     routing_key_fmt = 'config.callpickups.interceptors.users.updated'
 
-    def __init__(self, call_pickup_id: int, users: list[str], tenant_uuid: str):
+    def __init__(
+        self,
+        call_pickup_id: int,
+        users: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'call_pickup_id': call_pickup_id,
             'user_uuids': users,
@@ -22,7 +29,12 @@ class CallPickupTargetUsersAssociatedEvent(TenantEvent):
     name = 'call_pickup_target_users_associated'
     routing_key_fmt = 'config.callpickups.targets.users.updated'
 
-    def __init__(self, call_pickup_id: int, users: list[str], tenant_uuid: str):
+    def __init__(
+        self,
+        call_pickup_id: int,
+        users: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'call_pickup_id': call_pickup_id,
             'user_uuids': users,
@@ -35,7 +47,12 @@ class CallPickupInterceptorGroupsAssociatedEvent(TenantEvent):
     name = 'call_pickup_interceptor_groups_associated'
     routing_key_fmt = 'config.callpickups.interceptors.groups.updated'
 
-    def __init__(self, call_pickup_id: int, group_ids: list[int], tenant_uuid: str):
+    def __init__(
+        self,
+        call_pickup_id: int,
+        group_ids: list[int],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'call_pickup_id': call_pickup_id,
             'group_ids': group_ids,
@@ -48,7 +65,12 @@ class CallPickupTargetGroupsAssociatedEvent(TenantEvent):
     name = 'call_pickup_target_groups_associated'
     routing_key_fmt = 'config.callpickups.targets.groups.updated'
 
-    def __init__(self, call_pickup_id: int, group_ids: list[int], tenant_uuid: str):
+    def __init__(
+        self,
+        call_pickup_id: int,
+        group_ids: list[int],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'call_pickup_id': call_pickup_id,
             'group_ids': group_ids,

--- a/xivo_bus/resources/call_pickup_member/event.py
+++ b/xivo_bus/resources/call_pickup_member/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class CallPickupInterceptorUsersAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class CallPickupInterceptorUsersAssociatedEvent(TenantEvent):
         self,
         call_pickup_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'call_pickup_id': call_pickup_id,
@@ -34,7 +32,7 @@ class CallPickupTargetUsersAssociatedEvent(TenantEvent):
         self,
         call_pickup_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'call_pickup_id': call_pickup_id,
@@ -52,7 +50,7 @@ class CallPickupInterceptorGroupsAssociatedEvent(TenantEvent):
         self,
         call_pickup_id: int,
         group_ids: list[int],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'call_pickup_id': call_pickup_id,
@@ -70,7 +68,7 @@ class CallPickupTargetGroupsAssociatedEvent(TenantEvent):
         self,
         call_pickup_id: int,
         group_ids: list[int],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'call_pickup_id': call_pickup_id,

--- a/xivo_bus/resources/calls/application.py
+++ b/xivo_bus/resources/calls/application.py
@@ -1,9 +1,9 @@
-# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from xivo_bus.resources.common.event import TenantEvent, UserEvent
 
@@ -16,7 +16,12 @@ from .types import (
 
 
 class _ApplicationMixin:
-    def __init__(self, content: dict, application_uuid: str, *args: Any):
+    def __init__(
+        self,
+        content: dict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        *args: Any,
+    ):
         super().__init__(content, *args)  # type: ignore[call-arg]
         if application_uuid is None:
             raise ValueError('application_uuid must have a value')
@@ -29,7 +34,11 @@ class ApplicationCallDTMFReceivedEvent(_ApplicationMixin, TenantEvent):
     routing_key_fmt = 'applications.{application_uuid}.calls.{call_id}.dtmf.created'
 
     def __init__(
-        self, call_id: str, dtmf: str, application_uuid: str, tenant_uuid: str
+        self,
+        call_id: str,
+        dtmf: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -47,9 +56,9 @@ class ApplicationCallEnteredEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -63,9 +72,9 @@ class ApplicationCallInitiatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -79,9 +88,9 @@ class ApplicationCallDeletedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -95,9 +104,9 @@ class ApplicationCallUpdatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -111,9 +120,9 @@ class ApplicationCallAnsweredEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -129,9 +138,9 @@ class ApplicationCallProgressStartedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -147,9 +156,9 @@ class ApplicationCallProgressStoppedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -161,7 +170,10 @@ class ApplicationDestinationNodeCreatedEvent(_ApplicationMixin, TenantEvent):
     routing_key_fmt = 'applications.{application_uuid}.nodes.created'
 
     def __init__(
-        self, node: ApplicationNodeDict, application_uuid: str, tenant_uuid: str
+        self,
+        node: ApplicationNodeDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -173,7 +185,10 @@ class ApplicationNodeCreatedEvent(_ApplicationMixin, TenantEvent):
     routing_key_fmt = 'applications.{application_uuid}.nodes.created'
 
     def __init__(
-        self, node: ApplicationNodeDict, application_uuid: str, tenant_uuid: str
+        self,
+        node: ApplicationNodeDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -185,7 +200,10 @@ class ApplicationNodeUpdatedEvent(_ApplicationMixin, TenantEvent):
     routing_key_fmt = 'applications.{application_uuid}.nodes.{node[uuid]}.updated'
 
     def __init__(
-        self, node: ApplicationNodeDict, application_uuid: str, tenant_uuid: str
+        self,
+        node: ApplicationNodeDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -197,7 +215,10 @@ class ApplicationNodeDeletedEvent(_ApplicationMixin, TenantEvent):
     routing_key_fmt = 'applications.{application_uuid}.nodes.{node[uuid]}.deleted'
 
     def __init__(
-        self, node: ApplicationNodeDict, application_uuid: str, tenant_uuid: str
+        self,
+        node: ApplicationNodeDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -211,7 +232,10 @@ class ApplicationPlaybackCreatedEvent(_ApplicationMixin, TenantEvent):
     )
 
     def __init__(
-        self, playback: ApplicationCallPlayDict, application_uuid: str, tenant_uuid: str
+        self,
+        playback: ApplicationCallPlayDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -228,7 +252,10 @@ class ApplicationPlaybackDeletedEvent(_ApplicationMixin, TenantEvent):
     )
 
     def __init__(
-        self, playback: ApplicationCallPlayDict, application_uuid: str, tenant_uuid: str
+        self,
+        playback: ApplicationCallPlayDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -243,7 +270,10 @@ class ApplicationSnoopCreatedEvent(_ApplicationMixin, TenantEvent):
     routing_key_fmt = 'applications.{application_uuid}.snoops.{snoop[uuid]}.created'
 
     def __init__(
-        self, snoop: ApplicationSnoopDict, application_uuid: str, tenant_uuid: str
+        self,
+        snoop: ApplicationSnoopDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -255,7 +285,10 @@ class ApplicationSnoopUpdatedEvent(_ApplicationMixin, TenantEvent):
     routing_key_fmt = 'applications.{application_uuid}.snoops.{snoop[uuid]}.updated'
 
     def __init__(
-        self, snoop: ApplicationSnoopDict, application_uuid: str, tenant_uuid: str
+        self,
+        snoop: ApplicationSnoopDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -267,7 +300,10 @@ class ApplicationSnoopDeletedEvent(_ApplicationMixin, TenantEvent):
     routing_key_fmt = 'applications.{application_uuid}.snoops.{snoop[uuid]}.deleted'
 
     def __init__(
-        self, snoop: ApplicationSnoopDict, application_uuid: str, tenant_uuid: str
+        self,
+        snoop: ApplicationSnoopDict,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -283,9 +319,9 @@ class ApplicationUserOutgoingCallCreatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         call: ApplicationCallDict,
-        application_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        application_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'application_uuid': str(application_uuid), 'call': call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/calls/application.py
+++ b/xivo_bus/resources/calls/application.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from xivo_bus.resources.common.event import TenantEvent, UserEvent
-
+from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 from .types import (
     ApplicationCallDict,
     ApplicationCallPlayDict,
@@ -19,7 +19,7 @@ class _ApplicationMixin:
     def __init__(
         self,
         content: dict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
         *args: Any,
     ):
         super().__init__(content, *args)  # type: ignore[call-arg]
@@ -37,8 +37,8 @@ class ApplicationCallDTMFReceivedEvent(_ApplicationMixin, TenantEvent):
         self,
         call_id: str,
         dtmf: str,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -56,9 +56,9 @@ class ApplicationCallEnteredEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -72,9 +72,9 @@ class ApplicationCallInitiatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -88,9 +88,9 @@ class ApplicationCallDeletedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -104,9 +104,9 @@ class ApplicationCallUpdatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -120,9 +120,9 @@ class ApplicationCallAnsweredEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -138,9 +138,9 @@ class ApplicationCallProgressStartedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -156,9 +156,9 @@ class ApplicationCallProgressStoppedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -172,8 +172,8 @@ class ApplicationDestinationNodeCreatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         node: ApplicationNodeDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -187,8 +187,8 @@ class ApplicationNodeCreatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         node: ApplicationNodeDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -202,8 +202,8 @@ class ApplicationNodeUpdatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         node: ApplicationNodeDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -217,8 +217,8 @@ class ApplicationNodeDeletedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         node: ApplicationNodeDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -234,8 +234,8 @@ class ApplicationPlaybackCreatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         playback: ApplicationCallPlayDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -254,8 +254,8 @@ class ApplicationPlaybackDeletedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         playback: ApplicationCallPlayDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -272,8 +272,8 @@ class ApplicationSnoopCreatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         snoop: ApplicationSnoopDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -287,8 +287,8 @@ class ApplicationSnoopUpdatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         snoop: ApplicationSnoopDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -302,8 +302,8 @@ class ApplicationSnoopDeletedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         snoop: ApplicationSnoopDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -319,9 +319,9 @@ class ApplicationUserOutgoingCallCreatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         call: ApplicationCallDict,
-        application_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        application_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'application_uuid': str(application_uuid), 'call': call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/calls/application.py
+++ b/xivo_bus/resources/calls/application.py
@@ -3,10 +3,10 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Any
 
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import (
     ApplicationCallDict,
     ApplicationCallPlayDict,
@@ -19,7 +19,7 @@ class _ApplicationMixin:
     def __init__(
         self,
         content: dict,
-        application_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
         *args: Any,
     ):
         super().__init__(content, *args)  # type: ignore[call-arg]
@@ -37,8 +37,8 @@ class ApplicationCallDTMFReceivedEvent(_ApplicationMixin, TenantEvent):
         self,
         call_id: str,
         dtmf: str,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -56,9 +56,9 @@ class ApplicationCallEnteredEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -72,9 +72,9 @@ class ApplicationCallInitiatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -88,9 +88,9 @@ class ApplicationCallDeletedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -104,9 +104,9 @@ class ApplicationCallUpdatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -120,9 +120,9 @@ class ApplicationCallAnsweredEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -138,9 +138,9 @@ class ApplicationCallProgressStartedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -156,9 +156,9 @@ class ApplicationCallProgressStoppedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         application_call: ApplicationCallDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'call': application_call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)
@@ -172,8 +172,8 @@ class ApplicationDestinationNodeCreatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         node: ApplicationNodeDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -187,8 +187,8 @@ class ApplicationNodeCreatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         node: ApplicationNodeDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -202,8 +202,8 @@ class ApplicationNodeUpdatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         node: ApplicationNodeDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -217,8 +217,8 @@ class ApplicationNodeDeletedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         node: ApplicationNodeDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'node': node}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -234,8 +234,8 @@ class ApplicationPlaybackCreatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         playback: ApplicationCallPlayDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -254,8 +254,8 @@ class ApplicationPlaybackDeletedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         playback: ApplicationCallPlayDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'application_uuid': str(application_uuid),
@@ -272,8 +272,8 @@ class ApplicationSnoopCreatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         snoop: ApplicationSnoopDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -287,8 +287,8 @@ class ApplicationSnoopUpdatedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         snoop: ApplicationSnoopDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -302,8 +302,8 @@ class ApplicationSnoopDeletedEvent(_ApplicationMixin, TenantEvent):
     def __init__(
         self,
         snoop: ApplicationSnoopDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'snoop': snoop}
         super().__init__(content, application_uuid, tenant_uuid)
@@ -319,9 +319,9 @@ class ApplicationUserOutgoingCallCreatedEvent(_ApplicationMixin, UserEvent):
     def __init__(
         self,
         call: ApplicationCallDict,
-        application_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        application_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {'application_uuid': str(application_uuid), 'call': call}
         super().__init__(content, application_uuid, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/calls/event.py
+++ b/xivo_bus/resources/calls/event.py
@@ -1,10 +1,8 @@
 # Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import CallDict, RelocateDict, TransferDict
 
 
@@ -17,8 +15,8 @@ class CallCreatedEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -32,8 +30,8 @@ class CallEndedEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -47,8 +45,8 @@ class CallUpdatedEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -62,8 +60,8 @@ class CallAnsweredEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -78,8 +76,8 @@ class CallDTMFEvent(UserEvent):
         self,
         call_id: str,
         digit_number: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'call_id': call_id,
@@ -98,8 +96,8 @@ class CallHeldEvent(UserEvent):
     def __init__(
         self,
         call_id: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'call_id': call_id,
@@ -117,8 +115,8 @@ class CallResumedEvent(UserEvent):
     def __init__(
         self,
         call_id: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'call_id': call_id,
@@ -136,8 +134,8 @@ class MissedCallEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -151,8 +149,8 @@ class CallRelocateInitiatedEvent(UserEvent):
     def __init__(
         self,
         relocate: RelocateDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
@@ -166,8 +164,8 @@ class CallRelocateAnsweredEvent(UserEvent):
     def __init__(
         self,
         relocate: RelocateDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
@@ -181,8 +179,8 @@ class CallRelocateCompletedEvent(UserEvent):
     def __init__(
         self,
         relocate: RelocateDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
@@ -196,8 +194,8 @@ class CallRelocateEndedEvent(UserEvent):
     def __init__(
         self,
         relocate: RelocateDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
@@ -211,8 +209,8 @@ class CallTransferCreatedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -226,8 +224,8 @@ class CallTransferUpdatedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -241,8 +239,8 @@ class CallTransferAnsweredEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -256,8 +254,8 @@ class CallTransferCancelledEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -271,8 +269,8 @@ class CallTransferCompletedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -286,8 +284,8 @@ class CallTransferAbandonedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -301,7 +299,7 @@ class CallTransferEndedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/calls/event.py
+++ b/xivo_bus/resources/calls/event.py
@@ -1,5 +1,7 @@
-# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import UserEvent
 from .types import CallDict, RelocateDict, TransferDict
@@ -11,7 +13,12 @@ class CallCreatedEvent(UserEvent):
     routing_key_fmt = 'calls.call.created'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, call: CallDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call: CallDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(call, tenant_uuid, user_uuid)
 
 
@@ -21,7 +28,12 @@ class CallEndedEvent(UserEvent):
     routing_key_fmt = 'calls.call.ended'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, call: CallDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call: CallDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(call, tenant_uuid, user_uuid)
 
 
@@ -31,7 +43,12 @@ class CallUpdatedEvent(UserEvent):
     routing_key_fmt = 'calls.call.updated'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, call: CallDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call: CallDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(call, tenant_uuid, user_uuid)
 
 
@@ -41,7 +58,12 @@ class CallAnsweredEvent(UserEvent):
     routing_key_fmt = 'calls.call.answered'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, call: CallDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call: CallDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(call, tenant_uuid, user_uuid)
 
 
@@ -52,7 +74,11 @@ class CallDTMFEvent(UserEvent):
     required_acl_fmt = 'events.calls.{user_uuid}'
 
     def __init__(
-        self, call_id: str, digit_number: str, tenant_uuid: str, user_uuid: str
+        self,
+        call_id: str,
+        digit_number: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'call_id': call_id,
@@ -68,7 +94,12 @@ class CallHeldEvent(UserEvent):
     routing_key_fmt = 'calls.hold.created'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, call_id: str, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call_id: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'call_id': call_id,
             'user_uuid': str(user_uuid),
@@ -82,7 +113,12 @@ class CallResumedEvent(UserEvent):
     routing_key_fmt = 'calls.hold.deleted'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, call_id: str, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call_id: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'call_id': call_id,
             'user_uuid': str(user_uuid),
@@ -96,7 +132,12 @@ class MissedCallEvent(UserEvent):
     routing_key_fmt = 'calls.missed'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, call: CallDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call: CallDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(call, tenant_uuid, user_uuid)
 
 
@@ -106,7 +147,12 @@ class CallRelocateInitiatedEvent(UserEvent):
     routing_key_fmt = 'calls.relocate.created'
     required_acl_fmt = 'events.relocates.{user_uuid}'
 
-    def __init__(self, relocate: RelocateDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        relocate: RelocateDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
 
@@ -116,7 +162,12 @@ class CallRelocateAnsweredEvent(UserEvent):
     routing_key_fmt = 'calls.relocate.edited'
     required_acl_fmt = 'events.relocates.{user_uuid}'
 
-    def __init__(self, relocate: RelocateDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        relocate: RelocateDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
 
@@ -126,7 +177,12 @@ class CallRelocateCompletedEvent(UserEvent):
     routing_key_fmt = 'calls.relocate.edited'
     required_acl_fmt = 'events.relocates.{user_uuid}'
 
-    def __init__(self, relocate: RelocateDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        relocate: RelocateDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
 
@@ -136,7 +192,12 @@ class CallRelocateEndedEvent(UserEvent):
     routing_key_fmt = 'calls.relocate.deleted'
     required_acl_fmt = 'events.relocates.{user_uuid}'
 
-    def __init__(self, relocate: RelocateDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        relocate: RelocateDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
 
@@ -146,7 +207,12 @@ class CallTransferCreatedEvent(UserEvent):
     routing_key_fmt = 'calls.transfer.created'
     required_acl_fmt = 'events.transfers.{user_uuid}'
 
-    def __init__(self, transfer: TransferDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        transfer: TransferDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
 
@@ -156,7 +222,12 @@ class CallTransferUpdatedEvent(UserEvent):
     routing_key_fmt = 'calls.transfer.created'
     required_acl_fmt = 'events.transfers.{user_uuid}'
 
-    def __init__(self, transfer: TransferDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        transfer: TransferDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
 
@@ -166,7 +237,12 @@ class CallTransferAnsweredEvent(UserEvent):
     routing_key_fmt = 'calls.transfer.edited'
     required_acl_fmt = 'events.transfers.{user_uuid}'
 
-    def __init__(self, transfer: TransferDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        transfer: TransferDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
 
@@ -176,7 +252,12 @@ class CallTransferCancelledEvent(UserEvent):
     routing_key_fmt = 'calls.transfer.edited'
     required_acl_fmt = 'events.transfers.{user_uuid}'
 
-    def __init__(self, transfer: TransferDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        transfer: TransferDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
 
@@ -186,7 +267,12 @@ class CallTransferCompletedEvent(UserEvent):
     routing_key_fmt = 'calls.transfer.edited'
     required_acl_fmt = 'events.transfers.{user_uuid}'
 
-    def __init__(self, transfer: TransferDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        transfer: TransferDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
 
@@ -196,7 +282,12 @@ class CallTransferAbandonedEvent(UserEvent):
     routing_key_fmt = 'calls.transfer.edited'
     required_acl_fmt = 'events.transfers.{user_uuid}'
 
-    def __init__(self, transfer: TransferDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        transfer: TransferDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
 
@@ -206,5 +297,10 @@ class CallTransferEndedEvent(UserEvent):
     routing_key_fmt = 'calls.transfer.deleted'
     required_acl_fmt = 'events.transfers.{user_uuid}'
 
-    def __init__(self, transfer: TransferDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        transfer: TransferDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(transfer, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/calls/event.py
+++ b/xivo_bus/resources/calls/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 from .types import CallDict, RelocateDict, TransferDict
 
 
@@ -16,8 +17,8 @@ class CallCreatedEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -31,8 +32,8 @@ class CallEndedEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -46,8 +47,8 @@ class CallUpdatedEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -61,8 +62,8 @@ class CallAnsweredEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -77,8 +78,8 @@ class CallDTMFEvent(UserEvent):
         self,
         call_id: str,
         digit_number: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_id': call_id,
@@ -97,8 +98,8 @@ class CallHeldEvent(UserEvent):
     def __init__(
         self,
         call_id: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_id': call_id,
@@ -116,8 +117,8 @@ class CallResumedEvent(UserEvent):
     def __init__(
         self,
         call_id: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'call_id': call_id,
@@ -135,8 +136,8 @@ class MissedCallEvent(UserEvent):
     def __init__(
         self,
         call: CallDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(call, tenant_uuid, user_uuid)
 
@@ -150,8 +151,8 @@ class CallRelocateInitiatedEvent(UserEvent):
     def __init__(
         self,
         relocate: RelocateDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
@@ -165,8 +166,8 @@ class CallRelocateAnsweredEvent(UserEvent):
     def __init__(
         self,
         relocate: RelocateDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
@@ -180,8 +181,8 @@ class CallRelocateCompletedEvent(UserEvent):
     def __init__(
         self,
         relocate: RelocateDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
@@ -195,8 +196,8 @@ class CallRelocateEndedEvent(UserEvent):
     def __init__(
         self,
         relocate: RelocateDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(relocate, tenant_uuid, user_uuid)
 
@@ -210,8 +211,8 @@ class CallTransferCreatedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -225,8 +226,8 @@ class CallTransferUpdatedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -240,8 +241,8 @@ class CallTransferAnsweredEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -255,8 +256,8 @@ class CallTransferCancelledEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -270,8 +271,8 @@ class CallTransferCompletedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -285,8 +286,8 @@ class CallTransferAbandonedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)
 
@@ -300,7 +301,7 @@ class CallTransferEndedEvent(UserEvent):
     def __init__(
         self,
         transfer: TransferDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(transfer, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/calls/types.py
+++ b/xivo_bus/resources/calls/types.py
@@ -3,29 +3,29 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class ApplicationCallDict(TypedDict, total=False):
     id: str
     caller_id_name: str
     caller_id_number: str
-    creation_time: str
+    creation_time: Annotated[str, {'format': 'date-time'}]
     status: str
     on_hold: bool
     is_caller: bool
     dialed_extension: str
     variables: dict[str, str]
-    node_uuid: str
-    moh_uuid: str
+    node_uuid: Annotated[str, {'format': 'uuid'}]
+    moh_uuid: Annotated[str, {'format': 'uuid'}]
     muted: bool
     snoops: dict[str, str]
-    user_uuid: str
-    tenant_uuid: str
+    user_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
 
 
 class ApplicationCallPlayDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     uri: str
     language: str
 
@@ -35,12 +35,12 @@ class ApplicationNodeCallDict(TypedDict, total=False):
 
 
 class ApplicationNodeDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     calls: list[ApplicationNodeCallDict]
 
 
 class ApplicationSnoopDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     snooped_call_id: str
     snooping_call_id: str
 
@@ -59,7 +59,7 @@ class CallDict(TypedDict, total=False):
     muted: bool
     record_state: str
     talking_to: dict[str, str]
-    user_uuid: str
+    user_uuid: Annotated[str, {'format': 'uuid'}]
     is_caller: bool
     is_video: bool
     dialed_extension: str
@@ -70,7 +70,7 @@ class CallDict(TypedDict, total=False):
 
 
 class RelocateDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     relocated_call: str
     initiator_call: str
     recipient_call: str
@@ -82,8 +82,8 @@ class RelocateDict(TypedDict, total=False):
 
 class TransferDict(TypedDict, total=False):
     id: str
-    initiator_uuid: str
-    initiator_tenant_uuid: str
+    initiator_uuid: Annotated[str, {'format': 'uuid'}]
+    initiator_tenant_uuid: Annotated[str, {'format': 'uuid'}]
     transferred_call: str
     initiator_call: str
     recipient_call: str

--- a/xivo_bus/resources/calls/types.py
+++ b/xivo_bus/resources/calls/types.py
@@ -3,31 +3,31 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import DateTimeStr, UUIDStr
 
 
 class ApplicationCallDict(TypedDict, total=False):
     id: str
     caller_id_name: str
     caller_id_number: str
-    creation_time: Annotated[str, Format('date-time')]
+    creation_time: DateTimeStr
     status: str
     on_hold: bool
     is_caller: bool
     dialed_extension: str
     variables: dict[str, str]
-    node_uuid: Annotated[str, Format('uuid')]
-    moh_uuid: Annotated[str, Format('uuid')]
+    node_uuid: UUIDStr
+    moh_uuid: UUIDStr
     muted: bool
     snoops: dict[str, str]
-    user_uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    user_uuid: UUIDStr
+    tenant_uuid: UUIDStr
 
 
 class ApplicationCallPlayDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     uri: str
     language: str
 
@@ -37,12 +37,12 @@ class ApplicationNodeCallDict(TypedDict, total=False):
 
 
 class ApplicationNodeDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     calls: list[ApplicationNodeCallDict]
 
 
 class ApplicationSnoopDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     snooped_call_id: str
     snooping_call_id: str
 
@@ -61,7 +61,7 @@ class CallDict(TypedDict, total=False):
     muted: bool
     record_state: str
     talking_to: dict[str, str]
-    user_uuid: Annotated[str, Format('uuid')]
+    user_uuid: UUIDStr
     is_caller: bool
     is_video: bool
     dialed_extension: str
@@ -72,7 +72,7 @@ class CallDict(TypedDict, total=False):
 
 
 class RelocateDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     relocated_call: str
     initiator_call: str
     recipient_call: str
@@ -84,8 +84,8 @@ class RelocateDict(TypedDict, total=False):
 
 class TransferDict(TypedDict, total=False):
     id: str
-    initiator_uuid: Annotated[str, Format('uuid')]
-    initiator_tenant_uuid: Annotated[str, Format('uuid')]
+    initiator_uuid: UUIDStr
+    initiator_tenant_uuid: UUIDStr
     transferred_call: str
     initiator_call: str
     recipient_call: str

--- a/xivo_bus/resources/calls/types.py
+++ b/xivo_bus/resources/calls/types.py
@@ -5,27 +5,29 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class ApplicationCallDict(TypedDict, total=False):
     id: str
     caller_id_name: str
     caller_id_number: str
-    creation_time: Annotated[str, {'format': 'date-time'}]
+    creation_time: Annotated[str, Format('date-time')]
     status: str
     on_hold: bool
     is_caller: bool
     dialed_extension: str
     variables: dict[str, str]
-    node_uuid: Annotated[str, {'format': 'uuid'}]
-    moh_uuid: Annotated[str, {'format': 'uuid'}]
+    node_uuid: Annotated[str, Format('uuid')]
+    moh_uuid: Annotated[str, Format('uuid')]
     muted: bool
     snoops: dict[str, str]
-    user_uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    user_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
 
 
 class ApplicationCallPlayDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     uri: str
     language: str
 
@@ -35,12 +37,12 @@ class ApplicationNodeCallDict(TypedDict, total=False):
 
 
 class ApplicationNodeDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     calls: list[ApplicationNodeCallDict]
 
 
 class ApplicationSnoopDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     snooped_call_id: str
     snooping_call_id: str
 
@@ -59,7 +61,7 @@ class CallDict(TypedDict, total=False):
     muted: bool
     record_state: str
     talking_to: dict[str, str]
-    user_uuid: Annotated[str, {'format': 'uuid'}]
+    user_uuid: Annotated[str, Format('uuid')]
     is_caller: bool
     is_video: bool
     dialed_extension: str
@@ -70,7 +72,7 @@ class CallDict(TypedDict, total=False):
 
 
 class RelocateDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     relocated_call: str
     initiator_call: str
     recipient_call: str
@@ -82,8 +84,8 @@ class RelocateDict(TypedDict, total=False):
 
 class TransferDict(TypedDict, total=False):
     id: str
-    initiator_uuid: Annotated[str, {'format': 'uuid'}]
-    initiator_tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    initiator_uuid: Annotated[str, Format('uuid')]
+    initiator_tenant_uuid: Annotated[str, Format('uuid')]
     transferred_call: str
     initiator_call: str
     recipient_call: str

--- a/xivo_bus/resources/chatd/events.py
+++ b/xivo_bus/resources/chatd/events.py
@@ -3,10 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import MessageDict, RoomDict, UserPresenceDict
 
 
@@ -18,7 +16,7 @@ class PresenceUpdatedEvent(TenantEvent):
     def __init__(
         self,
         user_presence_data: UserPresenceDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(user_presence_data, tenant_uuid)
 
@@ -31,8 +29,8 @@ class UserRoomCreatedEvent(UserEvent):
     def __init__(
         self,
         room_data: RoomDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(room_data, tenant_uuid, user_uuid)
 
@@ -45,9 +43,9 @@ class UserRoomMessageCreatedEvent(UserEvent):
     def __init__(
         self,
         message_data: MessageDict,
-        room_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        room_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(message_data, tenant_uuid, user_uuid)
         if room_uuid is None:

--- a/xivo_bus/resources/chatd/events.py
+++ b/xivo_bus/resources/chatd/events.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 from .types import MessageDict, RoomDict, UserPresenceDict
 
 
@@ -17,7 +18,7 @@ class PresenceUpdatedEvent(TenantEvent):
     def __init__(
         self,
         user_presence_data: UserPresenceDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(user_presence_data, tenant_uuid)
 
@@ -30,8 +31,8 @@ class UserRoomCreatedEvent(UserEvent):
     def __init__(
         self,
         room_data: RoomDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(room_data, tenant_uuid, user_uuid)
 
@@ -44,9 +45,9 @@ class UserRoomMessageCreatedEvent(UserEvent):
     def __init__(
         self,
         message_data: MessageDict,
-        room_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        room_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(message_data, tenant_uuid, user_uuid)
         if room_uuid is None:

--- a/xivo_bus/resources/chatd/events.py
+++ b/xivo_bus/resources/chatd/events.py
@@ -1,7 +1,9 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
+
+from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
 from .types import MessageDict, RoomDict, UserPresenceDict
@@ -12,7 +14,11 @@ class PresenceUpdatedEvent(TenantEvent):
     name = 'chatd_presence_updated'
     routing_key_fmt = 'chatd.users.{uuid}.presences.updated'
 
-    def __init__(self, user_presence_data: UserPresenceDict, tenant_uuid: str):
+    def __init__(
+        self,
+        user_presence_data: UserPresenceDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(user_presence_data, tenant_uuid)
 
 
@@ -21,7 +27,12 @@ class UserRoomCreatedEvent(UserEvent):
     name = 'chatd_user_room_created'
     routing_key_fmt = 'chatd.users.{user_uuid}.rooms.created'
 
-    def __init__(self, room_data: RoomDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        room_data: RoomDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(room_data, tenant_uuid, user_uuid)
 
 
@@ -33,9 +44,9 @@ class UserRoomMessageCreatedEvent(UserEvent):
     def __init__(
         self,
         message_data: MessageDict,
-        room_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        room_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         super().__init__(message_data, tenant_uuid, user_uuid)
         if room_uuid is None:

--- a/xivo_bus/resources/chatd/types.py
+++ b/xivo_bus/resources/chatd/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class LinePresenceDict(TypedDict, total=False):
     id: int
@@ -12,32 +14,32 @@ class LinePresenceDict(TypedDict, total=False):
 
 
 class MessageDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     content: str
     alias: str
-    user_uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    wazo_uuid: Annotated[str, {'format': 'uuid'}]
+    user_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
+    wazo_uuid: Annotated[str, Format('uuid')]
     created_at: str
     room: RoomDict
 
 
 class RoomDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     name: str
     users: list[RoomUserDict]
 
 
 class RoomUserDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    wazo_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
+    wazo_uuid: Annotated[str, Format('uuid')]
 
 
 class UserPresenceDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     state: str
     status: str
     last_activity: str

--- a/xivo_bus/resources/chatd/types.py
+++ b/xivo_bus/resources/chatd/types.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class LinePresenceDict(TypedDict, total=False):
@@ -12,32 +12,32 @@ class LinePresenceDict(TypedDict, total=False):
 
 
 class MessageDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     content: str
     alias: str
-    user_uuid: str
-    tenant_uuid: str
-    wazo_uuid: str
+    user_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    wazo_uuid: Annotated[str, {'format': 'uuid'}]
     created_at: str
     room: RoomDict
 
 
 class RoomDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     name: str
     users: list[RoomUserDict]
 
 
 class RoomUserDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
-    wazo_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    wazo_uuid: Annotated[str, {'format': 'uuid'}]
 
 
 class UserPresenceDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     state: str
     status: str
     last_activity: str

--- a/xivo_bus/resources/chatd/types.py
+++ b/xivo_bus/resources/chatd/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class LinePresenceDict(TypedDict, total=False):
@@ -14,32 +14,32 @@ class LinePresenceDict(TypedDict, total=False):
 
 
 class MessageDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     content: str
     alias: str
-    user_uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
-    wazo_uuid: Annotated[str, Format('uuid')]
+    user_uuid: UUIDStr
+    tenant_uuid: UUIDStr
+    wazo_uuid: UUIDStr
     created_at: str
     room: RoomDict
 
 
 class RoomDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     name: str
     users: list[RoomUserDict]
 
 
 class RoomUserDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
-    wazo_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
+    wazo_uuid: UUIDStr
 
 
 class UserPresenceDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     state: str
     status: str
     last_activity: str

--- a/xivo_bus/resources/common/event.py
+++ b/xivo_bus/resources/common/event.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Annotated
 
 from .abstract import EventProtocol
 
@@ -31,7 +32,9 @@ class TenantEvent(ServiceEvent):
         - tenant_uuid
     '''
 
-    def __init__(self, content: Mapping | None, tenant_uuid: str):
+    def __init__(
+        self, content: Mapping | None, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(content)
         if tenant_uuid is None:
             raise ValueError('tenant_uuid must have a value')
@@ -53,7 +56,10 @@ class UserEvent(TenantEvent):
     '''
 
     def __init__(
-        self, content: Mapping | None, tenant_uuid: str, user_uuid: str | None
+        self,
+        content: Mapping | None,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}] | None,
     ):
         super().__init__(content, tenant_uuid)
         delattr(self, 'user_uuid:*')
@@ -84,7 +90,10 @@ class MultiUserEvent(TenantEvent):
     __slots__ = ('user_uuids',)
 
     def __init__(
-        self, content: Mapping | None, tenant_uuid: str, user_uuids: list[str]
+        self,
+        content: Mapping | None,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuids: list[str],
     ):
         super().__init__(content, tenant_uuid)
         delattr(self, 'user_uuid:*')

--- a/xivo_bus/resources/common/event.py
+++ b/xivo_bus/resources/common/event.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated
 
 from .abstract import EventProtocol
-from .types import Format
+from .types import UUIDStr
 
 
 class ServiceEvent(EventProtocol):
@@ -33,9 +32,7 @@ class TenantEvent(ServiceEvent):
         - tenant_uuid
     '''
 
-    def __init__(
-        self, content: Mapping | None, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, content: Mapping | None, tenant_uuid: UUIDStr):
         super().__init__(content)
         if tenant_uuid is None:
             raise ValueError('tenant_uuid must have a value')
@@ -59,8 +56,8 @@ class UserEvent(TenantEvent):
     def __init__(
         self,
         content: Mapping | None,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')] | None,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr | None,
     ):
         super().__init__(content, tenant_uuid)
         delattr(self, 'user_uuid:*')
@@ -93,8 +90,8 @@ class MultiUserEvent(TenantEvent):
     def __init__(
         self,
         content: Mapping | None,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuids: list[str],
+        tenant_uuid: UUIDStr,
+        user_uuids: list[UUIDStr],
     ):
         super().__init__(content, tenant_uuid)
         delattr(self, 'user_uuid:*')

--- a/xivo_bus/resources/common/event.py
+++ b/xivo_bus/resources/common/event.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Annotated
 
 from .abstract import EventProtocol
+from .types import Format
 
 
 class ServiceEvent(EventProtocol):
@@ -33,7 +34,7 @@ class TenantEvent(ServiceEvent):
     '''
 
     def __init__(
-        self, content: Mapping | None, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, content: Mapping | None, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(content)
         if tenant_uuid is None:
@@ -58,8 +59,8 @@ class UserEvent(TenantEvent):
     def __init__(
         self,
         content: Mapping | None,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}] | None,
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')] | None,
     ):
         super().__init__(content, tenant_uuid)
         delattr(self, 'user_uuid:*')
@@ -92,7 +93,7 @@ class MultiUserEvent(TenantEvent):
     def __init__(
         self,
         content: Mapping | None,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
         user_uuids: list[str],
     ):
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/common/types.py
+++ b/xivo_bus/resources/common/types.py
@@ -1,0 +1,19 @@
+# Copyright 2024 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+string_formats = Literal['date', 'date-time', 'uuid']
+
+
+@dataclass
+class Metadata:
+    format: string_formats | None = field(default=None)
+
+
+@dataclass
+class Format:
+    format: string_formats | None = field(default=None)

--- a/xivo_bus/resources/common/types.py
+++ b/xivo_bus/resources/common/types.py
@@ -4,16 +4,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Annotated, Literal
 
-string_formats = Literal['date', 'date-time', 'uuid']
-
-
-@dataclass
-class Metadata:
-    format: string_formats | None = field(default=None)
+_string_formats = Literal['date', 'date-time', 'uuid']
 
 
-@dataclass
+@dataclass(frozen=True)
 class Format:
-    format: string_formats | None = field(default=None)
+    format: _string_formats | None = field(default=None)
+
+
+# Type aliases
+UUIDStr = Annotated[str, Format('uuid')]
+DateTimeStr = Annotated[str, Format('date-time')]
+DateStr = Annotated[str, Format('date')]

--- a/xivo_bus/resources/conference/event.py
+++ b/xivo_bus/resources/conference/event.py
@@ -4,10 +4,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated, Any
+from typing import Any
 
 from ..common.event import MultiUserEvent, TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import ParticipantDict
 
 
@@ -24,7 +24,7 @@ class ConferenceCreatedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_created'
     routing_key_fmt = 'config.conferences.created'
 
-    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, conference_id: int, tenant_uuid: UUIDStr):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -34,7 +34,7 @@ class ConferenceDeletedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_deleted'
     routing_key_fmt = 'config.conferences.deleted'
 
-    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, conference_id: int, tenant_uuid: UUIDStr):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -44,7 +44,7 @@ class ConferenceEditedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_edited'
     routing_key_fmt = 'config.conferences.edited'
 
-    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, conference_id: int, tenant_uuid: UUIDStr):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -54,7 +54,7 @@ class ConferenceRecordStartedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_record_started'
     routing_key_fmt = 'conferences.{id}.record'
 
-    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, conference_id: int, tenant_uuid: UUIDStr):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -64,7 +64,7 @@ class ConferenceRecordStoppedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_record_stopped'
     routing_key_fmt = 'conferences.{id}.record'
 
-    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, conference_id: int, tenant_uuid: UUIDStr):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -78,7 +78,7 @@ class ConferenceParticipantJoinedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -94,7 +94,7 @@ class ConferenceParticipantLeftEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -110,7 +110,7 @@ class ConferenceParticipantMutedEvent(_ConferenceMixin, TenantEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid)
@@ -125,7 +125,7 @@ class ConferenceParticipantUnmutedEvent(_ConferenceMixin, TenantEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid)
@@ -140,7 +140,7 @@ class ConferenceParticipantTalkStartedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -156,7 +156,7 @@ class ConferenceParticipantTalkStoppedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -172,8 +172,8 @@ class ConferenceUserParticipantJoinedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -188,8 +188,8 @@ class ConferenceUserParticipantLeftEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -204,8 +204,8 @@ class ConferenceUserParticipantTalkStartedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -220,8 +220,8 @@ class ConferenceUserParticipantTalkStoppedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/conference/event.py
+++ b/xivo_bus/resources/conference/event.py
@@ -1,10 +1,10 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Annotated, Any
 
 from ..common.event import MultiUserEvent, TenantEvent, UserEvent
 from .types import ParticipantDict
@@ -23,7 +23,9 @@ class ConferenceCreatedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_created'
     routing_key_fmt = 'config.conferences.created'
 
-    def __init__(self, conference_id: int, tenant_uuid: str):
+    def __init__(
+        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -33,7 +35,9 @@ class ConferenceDeletedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_deleted'
     routing_key_fmt = 'config.conferences.deleted'
 
-    def __init__(self, conference_id: int, tenant_uuid: str):
+    def __init__(
+        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -43,7 +47,9 @@ class ConferenceEditedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_edited'
     routing_key_fmt = 'config.conferences.edited'
 
-    def __init__(self, conference_id: int, tenant_uuid: str):
+    def __init__(
+        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -53,7 +59,9 @@ class ConferenceRecordStartedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_record_started'
     routing_key_fmt = 'conferences.{id}.record'
 
-    def __init__(self, conference_id: int, tenant_uuid: str):
+    def __init__(
+        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -63,7 +71,9 @@ class ConferenceRecordStoppedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_record_stopped'
     routing_key_fmt = 'conferences.{id}.record'
 
-    def __init__(self, conference_id: int, tenant_uuid: str):
+    def __init__(
+        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -77,7 +87,7 @@ class ConferenceParticipantJoinedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -93,7 +103,7 @@ class ConferenceParticipantLeftEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -106,7 +116,10 @@ class ConferenceParticipantMutedEvent(_ConferenceMixin, TenantEvent):
     routing_key_fmt = 'conferences.{conference_id}.participants.mute'
 
     def __init__(
-        self, conference_id: int, participant: ParticipantDict, tenant_uuid: str
+        self,
+        conference_id: int,
+        participant: ParticipantDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid)
@@ -118,7 +131,10 @@ class ConferenceParticipantUnmutedEvent(_ConferenceMixin, TenantEvent):
     routing_key_fmt = 'conferences.{conference_id}.particpants.mute'
 
     def __init__(
-        self, conference_id: int, participant: ParticipantDict, tenant_uuid: str
+        self,
+        conference_id: int,
+        participant: ParticipantDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid)
@@ -133,7 +149,7 @@ class ConferenceParticipantTalkStartedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -149,7 +165,7 @@ class ConferenceParticipantTalkStoppedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -165,8 +181,8 @@ class ConferenceUserParticipantJoinedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -181,8 +197,8 @@ class ConferenceUserParticipantLeftEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -197,8 +213,8 @@ class ConferenceUserParticipantTalkStartedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -213,8 +229,8 @@ class ConferenceUserParticipantTalkStoppedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/conference/event.py
+++ b/xivo_bus/resources/conference/event.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Annotated, Any
 
 from ..common.event import MultiUserEvent, TenantEvent, UserEvent
+from ..common.types import Format
 from .types import ParticipantDict
 
 
@@ -23,9 +24,7 @@ class ConferenceCreatedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_created'
     routing_key_fmt = 'config.conferences.created'
 
-    def __init__(
-        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -35,9 +34,7 @@ class ConferenceDeletedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_deleted'
     routing_key_fmt = 'config.conferences.deleted'
 
-    def __init__(
-        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -47,9 +44,7 @@ class ConferenceEditedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_edited'
     routing_key_fmt = 'config.conferences.edited'
 
-    def __init__(
-        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -59,9 +54,7 @@ class ConferenceRecordStartedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_record_started'
     routing_key_fmt = 'conferences.{id}.record'
 
-    def __init__(
-        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -71,9 +64,7 @@ class ConferenceRecordStoppedEvent(_ConferenceMixin, TenantEvent):
     name = 'conference_record_stopped'
     routing_key_fmt = 'conferences.{id}.record'
 
-    def __init__(
-        self, conference_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, conference_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': conference_id}
         super().__init__(content, conference_id, tenant_uuid)
 
@@ -87,7 +78,7 @@ class ConferenceParticipantJoinedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -103,7 +94,7 @@ class ConferenceParticipantLeftEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -119,7 +110,7 @@ class ConferenceParticipantMutedEvent(_ConferenceMixin, TenantEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid)
@@ -134,7 +125,7 @@ class ConferenceParticipantUnmutedEvent(_ConferenceMixin, TenantEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid)
@@ -149,7 +140,7 @@ class ConferenceParticipantTalkStartedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -165,7 +156,7 @@ class ConferenceParticipantTalkStoppedEvent(_ConferenceMixin, MultiUserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
         user_uuids: list[str],
     ):
         content = dict(participant, conference_id=conference_id)
@@ -181,8 +172,8 @@ class ConferenceUserParticipantJoinedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -197,8 +188,8 @@ class ConferenceUserParticipantLeftEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -213,8 +204,8 @@ class ConferenceUserParticipantTalkStartedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)
@@ -229,8 +220,8 @@ class ConferenceUserParticipantTalkStoppedEvent(_ConferenceMixin, UserEvent):
         self,
         conference_id: int,
         participant: ParticipantDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, conference_id=conference_id)
         super().__init__(content, conference_id, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/conference/types.py
+++ b/xivo_bus/resources/conference/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class ParticipantDict(TypedDict, total=False):
     id: str
@@ -15,4 +17,4 @@ class ParticipantDict(TypedDict, total=False):
     admin: bool
     language: str
     call_id: str
-    user_uuid: Annotated[str, {'format': 'uuid'}]
+    user_uuid: Annotated[str, Format('uuid')]

--- a/xivo_bus/resources/conference/types.py
+++ b/xivo_bus/resources/conference/types.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class ParticipantDict(TypedDict, total=False):
@@ -15,4 +15,4 @@ class ParticipantDict(TypedDict, total=False):
     admin: bool
     language: str
     call_id: str
-    user_uuid: str
+    user_uuid: Annotated[str, {'format': 'uuid'}]

--- a/xivo_bus/resources/conference/types.py
+++ b/xivo_bus/resources/conference/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ParticipantDict(TypedDict, total=False):
@@ -17,4 +17,4 @@ class ParticipantDict(TypedDict, total=False):
     admin: bool
     language: str
     call_id: str
-    user_uuid: Annotated[str, Format('uuid')]
+    user_uuid: UUIDStr

--- a/xivo_bus/resources/conference_extension/event.py
+++ b/xivo_bus/resources/conference_extension/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class ConferenceExtensionAssociatedEvent(TenantEvent):
     name = 'conference_extension_associated'
     routing_key_fmt = 'config.conferences.extensions.updated'
 
-    def __init__(self, conference_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        conference_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'conference_id': conference_id,
             'extension_id': extension_id,
@@ -22,7 +29,12 @@ class ConferenceExtensionDissociatedEvent(TenantEvent):
     name = 'conference_extension_dissociated'
     routing_key_fmt = 'config.conferences.extensions.deleted'
 
-    def __init__(self, conference_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        conference_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'conference_id': conference_id,
             'extension_id': extension_id,

--- a/xivo_bus/resources/conference_extension/event.py
+++ b/xivo_bus/resources/conference_extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ConferenceExtensionAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class ConferenceExtensionAssociatedEvent(TenantEvent):
         self,
         conference_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'conference_id': conference_id,
@@ -34,7 +32,7 @@ class ConferenceExtensionDissociatedEvent(TenantEvent):
         self,
         conference_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'conference_id': conference_id,

--- a/xivo_bus/resources/conference_extension/event.py
+++ b/xivo_bus/resources/conference_extension/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class ConferenceExtensionAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class ConferenceExtensionAssociatedEvent(TenantEvent):
         self,
         conference_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'conference_id': conference_id,
@@ -33,7 +34,7 @@ class ConferenceExtensionDissociatedEvent(TenantEvent):
         self,
         conference_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'conference_id': conference_id,

--- a/xivo_bus/resources/context/event.py
+++ b/xivo_bus/resources/context/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import ContextDict
 
 
@@ -13,7 +14,7 @@ class ContextCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.contexts.created'
 
     def __init__(
-        self, context_data: ContextDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, context_data: ContextDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(context_data, tenant_uuid)
 
@@ -24,7 +25,7 @@ class ContextDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.contexts.deleted'
 
     def __init__(
-        self, context_data: ContextDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, context_data: ContextDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(context_data, tenant_uuid)
 
@@ -35,6 +36,6 @@ class ContextEditedEvent(TenantEvent):
     routing_key_fmt = 'config.contexts.edited'
 
     def __init__(
-        self, context_data: ContextDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, context_data: ContextDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(context_data, tenant_uuid)

--- a/xivo_bus/resources/context/event.py
+++ b/xivo_bus/resources/context/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import ContextDict
@@ -10,7 +12,9 @@ class ContextCreatedEvent(TenantEvent):
     name = 'context_created'
     routing_key_fmt = 'config.contexts.created'
 
-    def __init__(self, context_data: ContextDict, tenant_uuid: str):
+    def __init__(
+        self, context_data: ContextDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(context_data, tenant_uuid)
 
 
@@ -19,7 +23,9 @@ class ContextDeletedEvent(TenantEvent):
     name = 'context_deleted'
     routing_key_fmt = 'config.contexts.deleted'
 
-    def __init__(self, context_data: ContextDict, tenant_uuid: str):
+    def __init__(
+        self, context_data: ContextDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(context_data, tenant_uuid)
 
 
@@ -28,5 +34,7 @@ class ContextEditedEvent(TenantEvent):
     name = 'context_edited'
     routing_key_fmt = 'config.contexts.edited'
 
-    def __init__(self, context_data: ContextDict, tenant_uuid: str):
+    def __init__(
+        self, context_data: ContextDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(context_data, tenant_uuid)

--- a/xivo_bus/resources/context/event.py
+++ b/xivo_bus/resources/context/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import ContextDict
 
 
@@ -13,9 +11,7 @@ class ContextCreatedEvent(TenantEvent):
     name = 'context_created'
     routing_key_fmt = 'config.contexts.created'
 
-    def __init__(
-        self, context_data: ContextDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, context_data: ContextDict, tenant_uuid: UUIDStr):
         super().__init__(context_data, tenant_uuid)
 
 
@@ -24,9 +20,7 @@ class ContextDeletedEvent(TenantEvent):
     name = 'context_deleted'
     routing_key_fmt = 'config.contexts.deleted'
 
-    def __init__(
-        self, context_data: ContextDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, context_data: ContextDict, tenant_uuid: UUIDStr):
         super().__init__(context_data, tenant_uuid)
 
 
@@ -35,7 +29,5 @@ class ContextEditedEvent(TenantEvent):
     name = 'context_edited'
     routing_key_fmt = 'config.contexts.edited'
 
-    def __init__(
-        self, context_data: ContextDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, context_data: ContextDict, tenant_uuid: UUIDStr):
         super().__init__(context_data, tenant_uuid)

--- a/xivo_bus/resources/context/types.py
+++ b/xivo_bus/resources/context/types.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class ContextDict(TypedDict, total=False):
     id: int
     name: str
     type: str
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]

--- a/xivo_bus/resources/context/types.py
+++ b/xivo_bus/resources/context/types.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ContextDict(TypedDict, total=False):
     id: int
     name: str
     type: str
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr

--- a/xivo_bus/resources/context/types.py
+++ b/xivo_bus/resources/context/types.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class ContextDict(TypedDict, total=False):
     id: int
     name: str
     type: str
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]

--- a/xivo_bus/resources/context_context/event.py
+++ b/xivo_bus/resources/context_context/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class ContextContextsAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class ContextContextsAssociatedEvent(TenantEvent):
         self,
         context_id: int,
         context_ids: list[int],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'context_id': context_id,

--- a/xivo_bus/resources/context_context/event.py
+++ b/xivo_bus/resources/context_context/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ContextContextsAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class ContextContextsAssociatedEvent(TenantEvent):
         self,
         context_id: int,
         context_ids: list[int],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'context_id': context_id,

--- a/xivo_bus/resources/context_context/event.py
+++ b/xivo_bus/resources/context_context/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class ContextContextsAssociatedEvent(TenantEvent):
     name = 'contexts_associated'
     routing_key_fmt = 'config.contexts.contexts.updated'
 
-    def __init__(self, context_id: int, context_ids: list[int], tenant_uuid: str):
+    def __init__(
+        self,
+        context_id: int,
+        context_ids: list[int],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'context_id': context_id,
             'context_ids': context_ids,

--- a/xivo_bus/resources/device/event.py
+++ b/xivo_bus/resources/device/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class DeviceCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class DeviceCreatedEvent(TenantEvent):
     name = 'device_created'
     routing_key_fmt = 'config.device.created'
 
-    def __init__(self, device_id: str, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, device_id: str, tenant_uuid: UUIDStr):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class DeviceDeletedEvent(TenantEvent):
     name = 'device_deleted'
     routing_key_fmt = 'config.device.deleted'
 
-    def __init__(self, device_id: str, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, device_id: str, tenant_uuid: UUIDStr):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class DeviceEditedEvent(TenantEvent):
     name = 'device_edited'
     routing_key_fmt = 'config.device.edited'
 
-    def __init__(self, device_id: str, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, device_id: str, tenant_uuid: UUIDStr):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/device/event.py
+++ b/xivo_bus/resources/device/event.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,7 @@ class DeviceCreatedEvent(TenantEvent):
     name = 'device_created'
     routing_key_fmt = 'config.device.created'
 
-    def __init__(self, device_id: str, tenant_uuid: str):
+    def __init__(self, device_id: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +21,7 @@ class DeviceDeletedEvent(TenantEvent):
     name = 'device_deleted'
     routing_key_fmt = 'config.device.deleted'
 
-    def __init__(self, device_id: str, tenant_uuid: str):
+    def __init__(self, device_id: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +31,6 @@ class DeviceEditedEvent(TenantEvent):
     name = 'device_edited'
     routing_key_fmt = 'config.device.edited'
 
-    def __init__(self, device_id: str, tenant_uuid: str):
+    def __init__(self, device_id: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/device/event.py
+++ b/xivo_bus/resources/device/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class DeviceCreatedEvent(TenantEvent):
@@ -11,7 +12,7 @@ class DeviceCreatedEvent(TenantEvent):
     name = 'device_created'
     routing_key_fmt = 'config.device.created'
 
-    def __init__(self, device_id: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, device_id: str, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)
 
@@ -21,7 +22,7 @@ class DeviceDeletedEvent(TenantEvent):
     name = 'device_deleted'
     routing_key_fmt = 'config.device.deleted'
 
-    def __init__(self, device_id: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, device_id: str, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)
 
@@ -31,6 +32,6 @@ class DeviceEditedEvent(TenantEvent):
     name = 'device_edited'
     routing_key_fmt = 'config.device.edited'
 
-    def __init__(self, device_id: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, device_id: str, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': device_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/directory/event.py
+++ b/xivo_bus/resources/directory/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import UserEvent
 
@@ -13,9 +15,9 @@ class FavoriteAddedEvent(UserEvent):
         self,
         source_name: str,
         entry_id: str,
-        wazo_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        wazo_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'xivo_uuid': str(wazo_uuid),
@@ -35,9 +37,9 @@ class FavoriteDeletedEvent(UserEvent):
         self,
         source_name: str,
         entry_id: str,
-        wazo_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        wazo_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'xivo_uuid': str(wazo_uuid),

--- a/xivo_bus/resources/directory/event.py
+++ b/xivo_bus/resources/directory/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import UserEvent
+from ..common.event import UserEvent
+from ..common.types import Format
 
 
 class FavoriteAddedEvent(UserEvent):
@@ -15,9 +16,9 @@ class FavoriteAddedEvent(UserEvent):
         self,
         source_name: str,
         entry_id: str,
-        wazo_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        wazo_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'xivo_uuid': str(wazo_uuid),
@@ -37,9 +38,9 @@ class FavoriteDeletedEvent(UserEvent):
         self,
         source_name: str,
         entry_id: str,
-        wazo_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        wazo_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'xivo_uuid': str(wazo_uuid),

--- a/xivo_bus/resources/directory/event.py
+++ b/xivo_bus/resources/directory/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class FavoriteAddedEvent(UserEvent):
@@ -16,9 +14,9 @@ class FavoriteAddedEvent(UserEvent):
         self,
         source_name: str,
         entry_id: str,
-        wazo_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        wazo_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'xivo_uuid': str(wazo_uuid),
@@ -38,9 +36,9 @@ class FavoriteDeletedEvent(UserEvent):
         self,
         source_name: str,
         entry_id: str,
-        wazo_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        wazo_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'xivo_uuid': str(wazo_uuid),

--- a/xivo_bus/resources/endpoint_custom/event.py
+++ b/xivo_bus/resources/endpoint_custom/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import EndpointCustomDict
 
 
@@ -16,7 +14,7 @@ class CustomEndpointCreatedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointCustomDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -29,7 +27,7 @@ class CustomEndpointDeletedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointCustomDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -42,6 +40,6 @@ class CustomEndpointEditedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointCustomDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_custom/event.py
+++ b/xivo_bus/resources/endpoint_custom/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import EndpointCustomDict
@@ -10,7 +12,11 @@ class CustomEndpointCreatedEvent(TenantEvent):
     name = 'custom_endpoint_created'
     routing_key_fmt = 'config.custom_endpoint.created'
 
-    def __init__(self, endpoint: EndpointCustomDict, tenant_uuid: str):
+    def __init__(
+        self,
+        endpoint: EndpointCustomDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -19,7 +25,11 @@ class CustomEndpointDeletedEvent(TenantEvent):
     name = 'custom_endpoint_deleted'
     routing_key_fmt = 'config.custom_endpoint.deleted'
 
-    def __init__(self, endpoint: EndpointCustomDict, tenant_uuid: str):
+    def __init__(
+        self,
+        endpoint: EndpointCustomDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -28,5 +38,9 @@ class CustomEndpointEditedEvent(TenantEvent):
     name = 'custom_endpoint_edited'
     routing_key_fmt = 'config.custom_endpoint.edited'
 
-    def __init__(self, endpoint: EndpointCustomDict, tenant_uuid: str):
+    def __init__(
+        self,
+        endpoint: EndpointCustomDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_custom/event.py
+++ b/xivo_bus/resources/endpoint_custom/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import EndpointCustomDict
 
 
@@ -15,7 +16,7 @@ class CustomEndpointCreatedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointCustomDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -28,7 +29,7 @@ class CustomEndpointDeletedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointCustomDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -41,6 +42,6 @@ class CustomEndpointEditedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointCustomDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_custom/types.py
+++ b/xivo_bus/resources/endpoint_custom/types.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class EndpointCustomLineDict(TypedDict, total=False):
@@ -16,7 +16,7 @@ class EndpointCustomTrunkDict(TypedDict, total=False):
 
 class EndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     interface: str
     trunk: EndpointCustomTrunkDict
     line: EndpointCustomLineDict

--- a/xivo_bus/resources/endpoint_custom/types.py
+++ b/xivo_bus/resources/endpoint_custom/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class EndpointCustomLineDict(TypedDict, total=False):
@@ -18,7 +18,7 @@ class EndpointCustomTrunkDict(TypedDict, total=False):
 
 class EndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr
     interface: str
     trunk: EndpointCustomTrunkDict
     line: EndpointCustomLineDict

--- a/xivo_bus/resources/endpoint_custom/types.py
+++ b/xivo_bus/resources/endpoint_custom/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class EndpointCustomLineDict(TypedDict, total=False):
     id: int
@@ -16,7 +18,7 @@ class EndpointCustomTrunkDict(TypedDict, total=False):
 
 class EndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
     interface: str
     trunk: EndpointCustomTrunkDict
     line: EndpointCustomLineDict

--- a/xivo_bus/resources/endpoint_iax/event.py
+++ b/xivo_bus/resources/endpoint_iax/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import EndpointIAXDict
@@ -10,7 +12,9 @@ class IAXEndpointCreatedEvent(TenantEvent):
     name = 'iax_endpoint_created'
     routing_key_fmt = 'config.iax_endpoint.created'
 
-    def __init__(self, endpoint: EndpointIAXDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -19,7 +23,9 @@ class IAXEndpointDeletedEvent(TenantEvent):
     name = 'iax_endpoint_deleted'
     routing_key_fmt = 'config.iax_endpoint.deleted'
 
-    def __init__(self, endpoint: EndpointIAXDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -28,5 +34,7 @@ class IAXEndpointEditedEvent(TenantEvent):
     name = 'iax_endpoint_edited'
     routing_key_fmt = 'config.iax_endpoint.edited'
 
-    def __init__(self, endpoint: EndpointIAXDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_iax/event.py
+++ b/xivo_bus/resources/endpoint_iax/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import EndpointIAXDict
 
 
@@ -13,7 +14,7 @@ class IAXEndpointCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.iax_endpoint.created'
 
     def __init__(
-        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -24,7 +25,7 @@ class IAXEndpointDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.iax_endpoint.deleted'
 
     def __init__(
-        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -35,6 +36,6 @@ class IAXEndpointEditedEvent(TenantEvent):
     routing_key_fmt = 'config.iax_endpoint.edited'
 
     def __init__(
-        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_iax/event.py
+++ b/xivo_bus/resources/endpoint_iax/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import EndpointIAXDict
 
 
@@ -13,9 +11,7 @@ class IAXEndpointCreatedEvent(TenantEvent):
     name = 'iax_endpoint_created'
     routing_key_fmt = 'config.iax_endpoint.created'
 
-    def __init__(
-        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointIAXDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -24,9 +20,7 @@ class IAXEndpointDeletedEvent(TenantEvent):
     name = 'iax_endpoint_deleted'
     routing_key_fmt = 'config.iax_endpoint.deleted'
 
-    def __init__(
-        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointIAXDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -35,7 +29,5 @@ class IAXEndpointEditedEvent(TenantEvent):
     name = 'iax_endpoint_edited'
     routing_key_fmt = 'config.iax_endpoint.edited'
 
-    def __init__(
-        self, endpoint: EndpointIAXDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointIAXDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_iax/types.py
+++ b/xivo_bus/resources/endpoint_iax/types.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class EndpointIAXTrunkDict(TypedDict, total=False):
@@ -12,5 +12,5 @@ class EndpointIAXTrunkDict(TypedDict, total=False):
 
 class EndpointIAXDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     trunk: EndpointIAXTrunkDict

--- a/xivo_bus/resources/endpoint_iax/types.py
+++ b/xivo_bus/resources/endpoint_iax/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class EndpointIAXTrunkDict(TypedDict, total=False):
     id: int
@@ -12,5 +14,5 @@ class EndpointIAXTrunkDict(TypedDict, total=False):
 
 class EndpointIAXDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
     trunk: EndpointIAXTrunkDict

--- a/xivo_bus/resources/endpoint_iax/types.py
+++ b/xivo_bus/resources/endpoint_iax/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class EndpointIAXTrunkDict(TypedDict, total=False):
@@ -14,5 +14,5 @@ class EndpointIAXTrunkDict(TypedDict, total=False):
 
 class EndpointIAXDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr
     trunk: EndpointIAXTrunkDict

--- a/xivo_bus/resources/endpoint_sccp/event.py
+++ b/xivo_bus/resources/endpoint_sccp/event.py
@@ -1,10 +1,8 @@
 # Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import EndpointSCCPDict
 
 
@@ -16,7 +14,7 @@ class SCCPEndpointCreatedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointSCCPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -29,7 +27,7 @@ class SCCPEndpointDeletedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointSCCPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -42,6 +40,6 @@ class SCCPEndpointEditedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointSCCPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_sccp/event.py
+++ b/xivo_bus/resources/endpoint_sccp/event.py
@@ -1,5 +1,7 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import EndpointSCCPDict
@@ -10,7 +12,11 @@ class SCCPEndpointCreatedEvent(TenantEvent):
     name = 'sccp_endpoint_created'
     routing_key_fmt = 'config.sccp_endpoint.created'
 
-    def __init__(self, endpoint: EndpointSCCPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        endpoint: EndpointSCCPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -19,7 +25,11 @@ class SCCPEndpointDeletedEvent(TenantEvent):
     name = 'sccp_endpoint_deleted'
     routing_key_fmt = 'config.sccp_endpoint.deleted'
 
-    def __init__(self, endpoint: EndpointSCCPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        endpoint: EndpointSCCPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -28,5 +38,9 @@ class SCCPEndpointEditedEvent(TenantEvent):
     name = 'sccp_endpoint_edited'
     routing_key_fmt = 'config.sccp_endpoint.edited'
 
-    def __init__(self, endpoint: EndpointSCCPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        endpoint: EndpointSCCPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_sccp/event.py
+++ b/xivo_bus/resources/endpoint_sccp/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import EndpointSCCPDict
 
 
@@ -15,7 +16,7 @@ class SCCPEndpointCreatedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointSCCPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -28,7 +29,7 @@ class SCCPEndpointDeletedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointSCCPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -41,6 +42,6 @@ class SCCPEndpointEditedEvent(TenantEvent):
     def __init__(
         self,
         endpoint: EndpointSCCPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_sccp/types.py
+++ b/xivo_bus/resources/endpoint_sccp/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class EndpointSCCPLineDict(TypedDict, total=False):
     id: int
@@ -12,5 +14,5 @@ class EndpointSCCPLineDict(TypedDict, total=False):
 
 class EndpointSCCPDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
     line: EndpointSCCPLineDict

--- a/xivo_bus/resources/endpoint_sccp/types.py
+++ b/xivo_bus/resources/endpoint_sccp/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class EndpointSCCPLineDict(TypedDict, total=False):
@@ -14,5 +14,5 @@ class EndpointSCCPLineDict(TypedDict, total=False):
 
 class EndpointSCCPDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr
     line: EndpointSCCPLineDict

--- a/xivo_bus/resources/endpoint_sccp/types.py
+++ b/xivo_bus/resources/endpoint_sccp/types.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class EndpointSCCPLineDict(TypedDict, total=False):
@@ -12,5 +12,5 @@ class EndpointSCCPLineDict(TypedDict, total=False):
 
 class EndpointSCCPDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     line: EndpointSCCPLineDict

--- a/xivo_bus/resources/endpoint_sip/event.py
+++ b/xivo_bus/resources/endpoint_sip/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import EndpointSIPDict
 
 
@@ -13,7 +14,7 @@ class SIPEndpointCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.sip_endpoint.created'
 
     def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -24,7 +25,7 @@ class SIPEndpointDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.sip_endpoint.deleted'
 
     def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -35,7 +36,7 @@ class SIPEndpointEditedEvent(TenantEvent):
     routing_key_fmt = 'config.sip_endpoint.edited'
 
     def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -46,7 +47,7 @@ class SIPEndpointTemplateCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.sip_endpoint_template.created'
 
     def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -57,7 +58,7 @@ class SIPEndpointTemplateDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.sip_endpoint_template.deleted'
 
     def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)
 
@@ -68,6 +69,6 @@ class SIPEndpointTemplateEditedEvent(TenantEvent):
     routing_key_fmt = 'config.sip_endpoint_template.edited'
 
     def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_sip/event.py
+++ b/xivo_bus/resources/endpoint_sip/event.py
@@ -1,5 +1,7 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import EndpointSIPDict
@@ -10,7 +12,9 @@ class SIPEndpointCreatedEvent(TenantEvent):
     name = 'sip_endpoint_created'
     routing_key_fmt = 'config.sip_endpoint.created'
 
-    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -19,7 +23,9 @@ class SIPEndpointDeletedEvent(TenantEvent):
     name = 'sip_endpoint_deleted'
     routing_key_fmt = 'config.sip_endpoint.deleted'
 
-    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -28,7 +34,9 @@ class SIPEndpointEditedEvent(TenantEvent):
     name = 'sip_endpoint_edited'
     routing_key_fmt = 'config.sip_endpoint.edited'
 
-    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -37,7 +45,9 @@ class SIPEndpointTemplateCreatedEvent(TenantEvent):
     name = 'sip_endpoint_template_created'
     routing_key_fmt = 'config.sip_endpoint_template.created'
 
-    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -46,7 +56,9 @@ class SIPEndpointTemplateDeletedEvent(TenantEvent):
     name = 'sip_endpoint_template_deleted'
     routing_key_fmt = 'config.sip_endpoint_template.deleted'
 
-    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -55,5 +67,7 @@ class SIPEndpointTemplateEditedEvent(TenantEvent):
     name = 'sip_endpoint_template_edited'
     routing_key_fmt = 'config.sip_endpoint_template.edited'
 
-    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_sip/event.py
+++ b/xivo_bus/resources/endpoint_sip/event.py
@@ -1,10 +1,8 @@
 # Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import EndpointSIPDict
 
 
@@ -13,9 +11,7 @@ class SIPEndpointCreatedEvent(TenantEvent):
     name = 'sip_endpoint_created'
     routing_key_fmt = 'config.sip_endpoint.created'
 
-    def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -24,9 +20,7 @@ class SIPEndpointDeletedEvent(TenantEvent):
     name = 'sip_endpoint_deleted'
     routing_key_fmt = 'config.sip_endpoint.deleted'
 
-    def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -35,9 +29,7 @@ class SIPEndpointEditedEvent(TenantEvent):
     name = 'sip_endpoint_edited'
     routing_key_fmt = 'config.sip_endpoint.edited'
 
-    def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -46,9 +38,7 @@ class SIPEndpointTemplateCreatedEvent(TenantEvent):
     name = 'sip_endpoint_template_created'
     routing_key_fmt = 'config.sip_endpoint_template.created'
 
-    def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -57,9 +47,7 @@ class SIPEndpointTemplateDeletedEvent(TenantEvent):
     name = 'sip_endpoint_template_deleted'
     routing_key_fmt = 'config.sip_endpoint_template.deleted'
 
-    def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)
 
 
@@ -68,7 +56,5 @@ class SIPEndpointTemplateEditedEvent(TenantEvent):
     name = 'sip_endpoint_template_edited'
     routing_key_fmt = 'config.sip_endpoint_template.edited'
 
-    def __init__(
-        self, endpoint: EndpointSIPDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, endpoint: EndpointSIPDict, tenant_uuid: UUIDStr):
         super().__init__(endpoint, tenant_uuid)

--- a/xivo_bus/resources/endpoint_sip/types.py
+++ b/xivo_bus/resources/endpoint_sip/types.py
@@ -1,9 +1,9 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class EndpointSIPAuthSectionOptionsDict(TypedDict, total=False):
@@ -23,8 +23,8 @@ class EndpointSIPRegistrationSectionOptionsDict(TypedDict, total=False):
 
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     name: str
     label: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict

--- a/xivo_bus/resources/endpoint_sip/types.py
+++ b/xivo_bus/resources/endpoint_sip/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class EndpointSIPAuthSectionOptionsDict(TypedDict, total=False):
@@ -25,8 +25,8 @@ class EndpointSIPRegistrationSectionOptionsDict(TypedDict, total=False):
 
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     name: str
     label: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict

--- a/xivo_bus/resources/endpoint_sip/types.py
+++ b/xivo_bus/resources/endpoint_sip/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class EndpointSIPAuthSectionOptionsDict(TypedDict, total=False):
     username: str
@@ -23,8 +25,8 @@ class EndpointSIPRegistrationSectionOptionsDict(TypedDict, total=False):
 
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     name: str
     label: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict

--- a/xivo_bus/resources/extension/event.py
+++ b/xivo_bus/resources/extension/event.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,13 @@ class ExtensionCreatedEvent(TenantEvent):
     name = 'extension_created'
     routing_key_fmt = 'config.extensions.created'
 
-    def __init__(self, extension_id: int, exten: str, context: str, tenant_uuid: str):
+    def __init__(
+        self,
+        extension_id: int,
+        exten: str,
+        context: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'id': int(extension_id),
             'exten': exten,
@@ -23,7 +31,13 @@ class ExtensionDeletedEvent(TenantEvent):
     name = 'extension_deleted'
     routing_key_fmt = 'config.extensions.deleted'
 
-    def __init__(self, extension_id: int, exten: str, context: str, tenant_uuid: str):
+    def __init__(
+        self,
+        extension_id: int,
+        exten: str,
+        context: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'id': int(extension_id),
             'exten': exten,
@@ -37,7 +51,13 @@ class ExtensionEditedEvent(TenantEvent):
     name = 'extension_edited'
     routing_key_fmt = 'config.extensions.edited'
 
-    def __init__(self, extension_id: int, exten: str, context: str, tenant_uuid: str):
+    def __init__(
+        self,
+        extension_id: int,
+        exten: str,
+        context: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'id': int(extension_id),
             'exten': exten,

--- a/xivo_bus/resources/extension/event.py
+++ b/xivo_bus/resources/extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ExtensionCreatedEvent(TenantEvent):
@@ -17,7 +15,7 @@ class ExtensionCreatedEvent(TenantEvent):
         extension_id: int,
         exten: str,
         context: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'id': int(extension_id),
@@ -37,7 +35,7 @@ class ExtensionDeletedEvent(TenantEvent):
         extension_id: int,
         exten: str,
         context: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'id': int(extension_id),
@@ -57,7 +55,7 @@ class ExtensionEditedEvent(TenantEvent):
         extension_id: int,
         exten: str,
         context: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'id': int(extension_id),

--- a/xivo_bus/resources/extension/event.py
+++ b/xivo_bus/resources/extension/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class ExtensionCreatedEvent(TenantEvent):
@@ -16,7 +17,7 @@ class ExtensionCreatedEvent(TenantEvent):
         extension_id: int,
         exten: str,
         context: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': int(extension_id),
@@ -36,7 +37,7 @@ class ExtensionDeletedEvent(TenantEvent):
         extension_id: int,
         exten: str,
         context: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': int(extension_id),
@@ -56,7 +57,7 @@ class ExtensionEditedEvent(TenantEvent):
         extension_id: int,
         exten: str,
         context: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': int(extension_id),

--- a/xivo_bus/resources/extension_feature/event.py
+++ b/xivo_bus/resources/extension_feature/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import ServiceEvent
+from ..common.event import ServiceEvent
+from ..common.types import Format
 
 
 class ExtensionFeatureEditedEvent(ServiceEvent):
@@ -11,6 +12,6 @@ class ExtensionFeatureEditedEvent(ServiceEvent):
     name = 'extension_feature_edited'
     routing_key_fmt = 'config.extension_feature.edited'
 
-    def __init__(self, feature_extension_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, feature_extension_uuid: Annotated[str, Format('uuid')]):
         content = {'uuid': feature_extension_uuid}
         super().__init__(content)

--- a/xivo_bus/resources/extension_feature/event.py
+++ b/xivo_bus/resources/extension_feature/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import ServiceEvent
 
@@ -9,6 +11,6 @@ class ExtensionFeatureEditedEvent(ServiceEvent):
     name = 'extension_feature_edited'
     routing_key_fmt = 'config.extension_feature.edited'
 
-    def __init__(self, feature_extension_uuid: str):
+    def __init__(self, feature_extension_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'uuid': feature_extension_uuid}
         super().__init__(content)

--- a/xivo_bus/resources/extension_feature/event.py
+++ b/xivo_bus/resources/extension_feature/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import ServiceEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ExtensionFeatureEditedEvent(ServiceEvent):
@@ -12,6 +10,6 @@ class ExtensionFeatureEditedEvent(ServiceEvent):
     name = 'extension_feature_edited'
     routing_key_fmt = 'config.extension_feature.edited'
 
-    def __init__(self, feature_extension_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, feature_extension_uuid: UUIDStr):
         content = {'uuid': feature_extension_uuid}
         super().__init__(content)

--- a/xivo_bus/resources/external_app/event.py
+++ b/xivo_bus/resources/external_app/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import ExternalAppDict
 
 
@@ -13,7 +14,7 @@ class ExternalAppCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.external_apps.created'
 
     def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(app, tenant_uuid)
 
@@ -24,7 +25,7 @@ class ExternalAppDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.external_apps.deleted'
 
     def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(app, tenant_uuid)
 
@@ -35,6 +36,6 @@ class ExternalAppEditedEvent(TenantEvent):
     routing_key_fmt = 'config.external_apps.edited'
 
     def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(app, tenant_uuid)

--- a/xivo_bus/resources/external_app/event.py
+++ b/xivo_bus/resources/external_app/event.py
@@ -1,5 +1,7 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import ExternalAppDict
@@ -10,7 +12,9 @@ class ExternalAppCreatedEvent(TenantEvent):
     name = 'external_app_created'
     routing_key_fmt = 'config.external_apps.created'
 
-    def __init__(self, app: ExternalAppDict, tenant_uuid: str):
+    def __init__(
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(app, tenant_uuid)
 
 
@@ -19,7 +23,9 @@ class ExternalAppDeletedEvent(TenantEvent):
     name = 'external_app_deleted'
     routing_key_fmt = 'config.external_apps.deleted'
 
-    def __init__(self, app: ExternalAppDict, tenant_uuid: str):
+    def __init__(
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(app, tenant_uuid)
 
 
@@ -28,5 +34,7 @@ class ExternalAppEditedEvent(TenantEvent):
     name = 'external_app_edited'
     routing_key_fmt = 'config.external_apps.edited'
 
-    def __init__(self, app: ExternalAppDict, tenant_uuid: str):
+    def __init__(
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(app, tenant_uuid)

--- a/xivo_bus/resources/external_app/event.py
+++ b/xivo_bus/resources/external_app/event.py
@@ -1,10 +1,8 @@
 # Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import ExternalAppDict
 
 
@@ -13,9 +11,7 @@ class ExternalAppCreatedEvent(TenantEvent):
     name = 'external_app_created'
     routing_key_fmt = 'config.external_apps.created'
 
-    def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, app: ExternalAppDict, tenant_uuid: UUIDStr):
         super().__init__(app, tenant_uuid)
 
 
@@ -24,9 +20,7 @@ class ExternalAppDeletedEvent(TenantEvent):
     name = 'external_app_deleted'
     routing_key_fmt = 'config.external_apps.deleted'
 
-    def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, app: ExternalAppDict, tenant_uuid: UUIDStr):
         super().__init__(app, tenant_uuid)
 
 
@@ -35,7 +29,5 @@ class ExternalAppEditedEvent(TenantEvent):
     name = 'external_app_edited'
     routing_key_fmt = 'config.external_apps.edited'
 
-    def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, app: ExternalAppDict, tenant_uuid: UUIDStr):
         super().__init__(app, tenant_uuid)

--- a/xivo_bus/resources/faxes/event.py
+++ b/xivo_bus/resources/faxes/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 from .types import FaxDict
 
 
@@ -12,7 +13,7 @@ class FaxOutboundCreatedEvent(TenantEvent):
     name = 'fax_outbound_created'
     routing_key_fmt = 'faxes.outbound.created'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(fax, tenant_uuid)
 
 
@@ -21,7 +22,7 @@ class FaxOutboundSucceededEvent(TenantEvent):
     name = 'fax_outbound_succeeded'
     routing_key_fmt = 'faxes.outbound.{id}.succeeded'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(fax, tenant_uuid)
 
 
@@ -30,7 +31,7 @@ class FaxOutboundFailedEvent(TenantEvent):
     name = 'fax_outbound_failed'
     routing_key_fmt = 'faxes.outbound.{id}.failed'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(fax, tenant_uuid)
 
 
@@ -42,8 +43,8 @@ class FaxOutboundUserCreatedEvent(UserEvent):
     def __init__(
         self,
         fax: FaxDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(fax, tenant_uuid, user_uuid)
 
@@ -56,8 +57,8 @@ class FaxOutboundUserSucceededEvent(UserEvent):
     def __init__(
         self,
         fax: FaxDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(fax, tenant_uuid, user_uuid)
 
@@ -70,7 +71,7 @@ class FaxOutboundUserFailedEvent(UserEvent):
     def __init__(
         self,
         fax: FaxDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(fax, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/faxes/event.py
+++ b/xivo_bus/resources/faxes/event.py
@@ -1,5 +1,7 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
 from .types import FaxDict
@@ -10,7 +12,7 @@ class FaxOutboundCreatedEvent(TenantEvent):
     name = 'fax_outbound_created'
     routing_key_fmt = 'faxes.outbound.created'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: str):
+    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(fax, tenant_uuid)
 
 
@@ -19,7 +21,7 @@ class FaxOutboundSucceededEvent(TenantEvent):
     name = 'fax_outbound_succeeded'
     routing_key_fmt = 'faxes.outbound.{id}.succeeded'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: str):
+    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(fax, tenant_uuid)
 
 
@@ -28,7 +30,7 @@ class FaxOutboundFailedEvent(TenantEvent):
     name = 'fax_outbound_failed'
     routing_key_fmt = 'faxes.outbound.{id}.failed'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: str):
+    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(fax, tenant_uuid)
 
 
@@ -37,7 +39,12 @@ class FaxOutboundUserCreatedEvent(UserEvent):
     name = 'fax_outbound_user_created'
     routing_key_fmt = 'faxes.outbound.users.{user_uuid}.created'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        fax: FaxDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(fax, tenant_uuid, user_uuid)
 
 
@@ -46,7 +53,12 @@ class FaxOutboundUserSucceededEvent(UserEvent):
     name = 'fax_outbound_user_succeeded'
     routing_key_fmt = 'faxes.outbound.users.{user_uuid}.succeeded'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        fax: FaxDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(fax, tenant_uuid, user_uuid)
 
 
@@ -55,5 +67,10 @@ class FaxOutboundUserFailedEvent(UserEvent):
     name = 'fax_outbound_user_failed'
     routing_key_fmt = 'faxes.outbound.users.{user_uuid}.failed'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        fax: FaxDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(fax, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/faxes/event.py
+++ b/xivo_bus/resources/faxes/event.py
@@ -1,10 +1,8 @@
 # Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import FaxDict
 
 
@@ -13,7 +11,7 @@ class FaxOutboundCreatedEvent(TenantEvent):
     name = 'fax_outbound_created'
     routing_key_fmt = 'faxes.outbound.created'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, fax: FaxDict, tenant_uuid: UUIDStr):
         super().__init__(fax, tenant_uuid)
 
 
@@ -22,7 +20,7 @@ class FaxOutboundSucceededEvent(TenantEvent):
     name = 'fax_outbound_succeeded'
     routing_key_fmt = 'faxes.outbound.{id}.succeeded'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, fax: FaxDict, tenant_uuid: UUIDStr):
         super().__init__(fax, tenant_uuid)
 
 
@@ -31,7 +29,7 @@ class FaxOutboundFailedEvent(TenantEvent):
     name = 'fax_outbound_failed'
     routing_key_fmt = 'faxes.outbound.{id}.failed'
 
-    def __init__(self, fax: FaxDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, fax: FaxDict, tenant_uuid: UUIDStr):
         super().__init__(fax, tenant_uuid)
 
 
@@ -43,8 +41,8 @@ class FaxOutboundUserCreatedEvent(UserEvent):
     def __init__(
         self,
         fax: FaxDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(fax, tenant_uuid, user_uuid)
 
@@ -57,8 +55,8 @@ class FaxOutboundUserSucceededEvent(UserEvent):
     def __init__(
         self,
         fax: FaxDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(fax, tenant_uuid, user_uuid)
 
@@ -71,7 +69,7 @@ class FaxOutboundUserFailedEvent(UserEvent):
     def __init__(
         self,
         fax: FaxDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(fax, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/faxes/types.py
+++ b/xivo_bus/resources/faxes/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class FaxDict(TypedDict, total=False):
@@ -16,5 +16,5 @@ class FaxDict(TypedDict, total=False):
     caller_id: str
     ivr_extension: str
     wait_time: int
-    user_uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    user_uuid: UUIDStr
+    tenant_uuid: UUIDStr

--- a/xivo_bus/resources/faxes/types.py
+++ b/xivo_bus/resources/faxes/types.py
@@ -1,9 +1,9 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class FaxDict(TypedDict, total=False):
@@ -14,5 +14,5 @@ class FaxDict(TypedDict, total=False):
     caller_id: str
     ivr_extension: str
     wait_time: int
-    user_uuid: str
-    tenant_uuid: str
+    user_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]

--- a/xivo_bus/resources/faxes/types.py
+++ b/xivo_bus/resources/faxes/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class FaxDict(TypedDict, total=False):
     id: str
@@ -14,5 +16,5 @@ class FaxDict(TypedDict, total=False):
     caller_id: str
     ivr_extension: str
     wait_time: int
-    user_uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    user_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]

--- a/xivo_bus/resources/func_key/event.py
+++ b/xivo_bus/resources/func_key/event.py
@@ -1,5 +1,7 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class FuncKeyTemplateCreatedEvent(TenantEvent):
     name = 'func_key_template_created'
     routing_key_fmt = 'config.funckey.template.created'
 
-    def __init__(self, template_id: int, tenant_uuid: str):
+    def __init__(
+        self, template_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +23,9 @@ class FuncKeyTemplateDeletedEvent(TenantEvent):
     name = 'func_key_template_deleted'
     routing_key_fmt = 'config.funckey.template.deleted'
 
-    def __init__(self, template_id: int, tenant_uuid: str):
+    def __init__(
+        self, template_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +35,8 @@ class FuncKeyTemplateEditedEvent(TenantEvent):
     name = 'func_key_template_edited'
     routing_key_fmt = 'config.funckey.template.edited'
 
-    def __init__(self, template_id: int, tenant_uuid: str):
+    def __init__(
+        self, template_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/func_key/event.py
+++ b/xivo_bus/resources/func_key/event.py
@@ -1,10 +1,8 @@
 # Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class FuncKeyTemplateCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class FuncKeyTemplateCreatedEvent(TenantEvent):
     name = 'func_key_template_created'
     routing_key_fmt = 'config.funckey.template.created'
 
-    def __init__(self, template_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, template_id: int, tenant_uuid: UUIDStr):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class FuncKeyTemplateDeletedEvent(TenantEvent):
     name = 'func_key_template_deleted'
     routing_key_fmt = 'config.funckey.template.deleted'
 
-    def __init__(self, template_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, template_id: int, tenant_uuid: UUIDStr):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class FuncKeyTemplateEditedEvent(TenantEvent):
     name = 'func_key_template_edited'
     routing_key_fmt = 'config.funckey.template.edited'
 
-    def __init__(self, template_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, template_id: int, tenant_uuid: UUIDStr):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/func_key/event.py
+++ b/xivo_bus/resources/func_key/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class FuncKeyTemplateCreatedEvent(TenantEvent):
@@ -11,9 +12,7 @@ class FuncKeyTemplateCreatedEvent(TenantEvent):
     name = 'func_key_template_created'
     routing_key_fmt = 'config.funckey.template.created'
 
-    def __init__(
-        self, template_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, template_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)
 
@@ -23,9 +22,7 @@ class FuncKeyTemplateDeletedEvent(TenantEvent):
     name = 'func_key_template_deleted'
     routing_key_fmt = 'config.funckey.template.deleted'
 
-    def __init__(
-        self, template_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, template_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)
 
@@ -35,8 +32,6 @@ class FuncKeyTemplateEditedEvent(TenantEvent):
     name = 'func_key_template_edited'
     routing_key_fmt = 'config.funckey.template.edited'
 
-    def __init__(
-        self, template_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, template_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': template_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/group/event.py
+++ b/xivo_bus/resources/group/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import GroupDict
@@ -10,7 +12,9 @@ class GroupCreatedEvent(TenantEvent):
     name = 'group_created'
     routing_key_fmt = 'config.groups.created'
 
-    def __init__(self, group: GroupDict, tenant_uuid: str):
+    def __init__(
+        self, group: GroupDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(group, tenant_uuid)
 
 
@@ -19,7 +23,9 @@ class GroupDeletedEvent(TenantEvent):
     name = 'group_deleted'
     routing_key_fmt = 'config.groups.deleted'
 
-    def __init__(self, group: GroupDict, tenant_uuid: str):
+    def __init__(
+        self, group: GroupDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(group, tenant_uuid)
 
 
@@ -28,7 +34,9 @@ class GroupEditedEvent(TenantEvent):
     name = 'group_edited'
     routing_key_fmt = 'config.groups.edited'
 
-    def __init__(self, group: GroupDict, tenant_uuid: str):
+    def __init__(
+        self, group: GroupDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(group, tenant_uuid)
 
 
@@ -37,7 +45,12 @@ class GroupFallbackEditedEvent(TenantEvent):
     name = 'group_fallback_edited'
     routing_key_fmt = 'config.groups.fallbacks.edited'
 
-    def __init__(self, group_id: int, group_uuid: str, tenant_uuid: str):
+    def __init__(
+        self,
+        group_id: int,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'id': group_id,
             'uuid': str(group_uuid),

--- a/xivo_bus/resources/group/event.py
+++ b/xivo_bus/resources/group/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import GroupDict
 
 
@@ -12,9 +13,7 @@ class GroupCreatedEvent(TenantEvent):
     name = 'group_created'
     routing_key_fmt = 'config.groups.created'
 
-    def __init__(
-        self, group: GroupDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, group: GroupDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(group, tenant_uuid)
 
 
@@ -23,9 +22,7 @@ class GroupDeletedEvent(TenantEvent):
     name = 'group_deleted'
     routing_key_fmt = 'config.groups.deleted'
 
-    def __init__(
-        self, group: GroupDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, group: GroupDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(group, tenant_uuid)
 
 
@@ -34,9 +31,7 @@ class GroupEditedEvent(TenantEvent):
     name = 'group_edited'
     routing_key_fmt = 'config.groups.edited'
 
-    def __init__(
-        self, group: GroupDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, group: GroupDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(group, tenant_uuid)
 
 
@@ -48,8 +43,8 @@ class GroupFallbackEditedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': group_id,

--- a/xivo_bus/resources/group/event.py
+++ b/xivo_bus/resources/group/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import GroupDict
 
 
@@ -13,7 +11,7 @@ class GroupCreatedEvent(TenantEvent):
     name = 'group_created'
     routing_key_fmt = 'config.groups.created'
 
-    def __init__(self, group: GroupDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, group: GroupDict, tenant_uuid: UUIDStr):
         super().__init__(group, tenant_uuid)
 
 
@@ -22,7 +20,7 @@ class GroupDeletedEvent(TenantEvent):
     name = 'group_deleted'
     routing_key_fmt = 'config.groups.deleted'
 
-    def __init__(self, group: GroupDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, group: GroupDict, tenant_uuid: UUIDStr):
         super().__init__(group, tenant_uuid)
 
 
@@ -31,7 +29,7 @@ class GroupEditedEvent(TenantEvent):
     name = 'group_edited'
     routing_key_fmt = 'config.groups.edited'
 
-    def __init__(self, group: GroupDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, group: GroupDict, tenant_uuid: UUIDStr):
         super().__init__(group, tenant_uuid)
 
 
@@ -43,8 +41,8 @@ class GroupFallbackEditedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'id': group_id,

--- a/xivo_bus/resources/group/types.py
+++ b/xivo_bus/resources/group/types.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class GroupDict(TypedDict, total=False):
     id: int
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]

--- a/xivo_bus/resources/group/types.py
+++ b/xivo_bus/resources/group/types.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class GroupDict(TypedDict, total=False):
     id: int
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr

--- a/xivo_bus/resources/group/types.py
+++ b/xivo_bus/resources/group/types.py
@@ -1,11 +1,11 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class GroupDict(TypedDict, total=False):
     id: int
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]

--- a/xivo_bus/resources/group_call_permission/event.py
+++ b/xivo_bus/resources/group_call_permission/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -10,7 +12,11 @@ class GroupCallPermissionAssociatedEvent(TenantEvent):
     routing_key_fmt = 'config.groups.{group_uuid}.callpermissions.updated'
 
     def __init__(
-        self, group_id: int, group_uuid: str, call_permission_id: int, tenant_uuid: str
+        self,
+        group_id: int,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
+        call_permission_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'group_id': group_id,
@@ -26,7 +32,11 @@ class GroupCallPermissionDissociatedEvent(TenantEvent):
     routing_key_fmt = 'config.groups.{group_uuid}.callpermissions.deleted'
 
     def __init__(
-        self, group_id: int, group_uuid: str, call_permission_id: int, tenant_uuid: str
+        self,
+        group_id: int,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
+        call_permission_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_call_permission/event.py
+++ b/xivo_bus/resources/group_call_permission/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class GroupCallPermissionAssociatedEvent(TenantEvent):
@@ -14,9 +15,9 @@ class GroupCallPermissionAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
         call_permission_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'group_id': group_id,
@@ -34,9 +35,9 @@ class GroupCallPermissionDissociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
         call_permission_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_call_permission/event.py
+++ b/xivo_bus/resources/group_call_permission/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class GroupCallPermissionAssociatedEvent(TenantEvent):
@@ -15,9 +13,9 @@ class GroupCallPermissionAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'group_id': group_id,
@@ -35,9 +33,9 @@ class GroupCallPermissionDissociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_extension/event.py
+++ b/xivo_bus/resources/group_extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class GroupExtensionAssociatedEvent(TenantEvent):
@@ -15,9 +13,9 @@ class GroupExtensionAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'group_id': group_id,
@@ -35,9 +33,9 @@ class GroupExtensionDissociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_extension/event.py
+++ b/xivo_bus/resources/group_extension/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -10,7 +12,11 @@ class GroupExtensionAssociatedEvent(TenantEvent):
     routing_key_fmt = 'config.groups.extensions.updated'
 
     def __init__(
-        self, group_id: int, group_uuid: str, extension_id: int, tenant_uuid: str
+        self,
+        group_id: int,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'group_id': group_id,
@@ -26,7 +32,11 @@ class GroupExtensionDissociatedEvent(TenantEvent):
     routing_key_fmt = 'config.groups.extensions.deleted'
 
     def __init__(
-        self, group_id: int, group_uuid: str, extension_id: int, tenant_uuid: str
+        self,
+        group_id: int,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_extension/event.py
+++ b/xivo_bus/resources/group_extension/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class GroupExtensionAssociatedEvent(TenantEvent):
@@ -14,9 +15,9 @@ class GroupExtensionAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'group_id': group_id,
@@ -34,9 +35,9 @@ class GroupExtensionDissociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_member/event.py
+++ b/xivo_bus/resources/group_member/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import GroupExtensionDict
 
 
@@ -16,9 +14,9 @@ class GroupMemberUsersAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
         users: list[str],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'group_id': group_id,
@@ -36,9 +34,9 @@ class GroupMemberExtensionsAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
         extensions: list[GroupExtensionDict],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_member/event.py
+++ b/xivo_bus/resources/group_member/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import GroupExtensionDict
@@ -11,7 +13,11 @@ class GroupMemberUsersAssociatedEvent(TenantEvent):
     routing_key_fmt = 'config.groups.members.users.updated'
 
     def __init__(
-        self, group_id: int, group_uuid: str, users: list[str], tenant_uuid: str
+        self,
+        group_id: int,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
+        users: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'group_id': group_id,
@@ -29,9 +35,9 @@ class GroupMemberExtensionsAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: str,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
         extensions: list[GroupExtensionDict],
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_member/event.py
+++ b/xivo_bus/resources/group_member/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import GroupExtensionDict
 
 
@@ -15,9 +16,9 @@ class GroupMemberUsersAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
         users: list[str],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'group_id': group_id,
@@ -35,9 +36,9 @@ class GroupMemberExtensionsAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
         extensions: list[GroupExtensionDict],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_schedule/event.py
+++ b/xivo_bus/resources/group_schedule/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -10,7 +12,11 @@ class GroupScheduleAssociatedEvent(TenantEvent):
     routing_key_fmt = 'config.groups.schedules.updated'
 
     def __init__(
-        self, group_id: int, group_uuid: str, schedule_id: int, tenant_uuid: str
+        self,
+        group_id: int,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'group_id': group_id,
@@ -26,7 +32,11 @@ class GroupScheduleDissociatedEvent(TenantEvent):
     routing_key_fmt = 'config.groups.schedules.deleted'
 
     def __init__(
-        self, group_id: int, group_uuid: str, schedule_id: int, tenant_uuid: str
+        self,
+        group_id: int,
+        group_uuid: Annotated[str, {'format': 'uuid'}],
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_schedule/event.py
+++ b/xivo_bus/resources/group_schedule/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class GroupScheduleAssociatedEvent(TenantEvent):
@@ -14,9 +15,9 @@ class GroupScheduleAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'group_id': group_id,
@@ -34,9 +35,9 @@ class GroupScheduleDissociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, {'format': 'uuid'}],
+        group_uuid: Annotated[str, Format('uuid')],
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/group_schedule/event.py
+++ b/xivo_bus/resources/group_schedule/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class GroupScheduleAssociatedEvent(TenantEvent):
@@ -15,9 +13,9 @@ class GroupScheduleAssociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'group_id': group_id,
@@ -35,9 +33,9 @@ class GroupScheduleDissociatedEvent(TenantEvent):
     def __init__(
         self,
         group_id: int,
-        group_uuid: Annotated[str, Format('uuid')],
+        group_uuid: UUIDStr,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'group_id': group_id,

--- a/xivo_bus/resources/incall/event.py
+++ b/xivo_bus/resources/incall/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class IncallCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class IncallCreatedEvent(TenantEvent):
     name = 'incall_created'
     routing_key_fmt = 'config.incalls.created'
 
-    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, incall_id: int, tenant_uuid: UUIDStr):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class IncallDeletedEvent(TenantEvent):
     name = 'incall_deleted'
     routing_key_fmt = 'config.incalls.deleted'
 
-    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, incall_id: int, tenant_uuid: UUIDStr):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class IncallEditedEvent(TenantEvent):
     name = 'incall_edited'
     routing_key_fmt = 'config.incalls.edited'
 
-    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, incall_id: int, tenant_uuid: UUIDStr):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/incall/event.py
+++ b/xivo_bus/resources/incall/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class IncallCreatedEvent(TenantEvent):
@@ -11,7 +12,7 @@ class IncallCreatedEvent(TenantEvent):
     name = 'incall_created'
     routing_key_fmt = 'config.incalls.created'
 
-    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)
 
@@ -21,7 +22,7 @@ class IncallDeletedEvent(TenantEvent):
     name = 'incall_deleted'
     routing_key_fmt = 'config.incalls.deleted'
 
-    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)
 
@@ -31,6 +32,6 @@ class IncallEditedEvent(TenantEvent):
     name = 'incall_edited'
     routing_key_fmt = 'config.incalls.edited'
 
-    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/incall/event.py
+++ b/xivo_bus/resources/incall/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,7 @@ class IncallCreatedEvent(TenantEvent):
     name = 'incall_created'
     routing_key_fmt = 'config.incalls.created'
 
-    def __init__(self, incall_id: int, tenant_uuid: str):
+    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +21,7 @@ class IncallDeletedEvent(TenantEvent):
     name = 'incall_deleted'
     routing_key_fmt = 'config.incalls.deleted'
 
-    def __init__(self, incall_id: int, tenant_uuid: str):
+    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +31,6 @@ class IncallEditedEvent(TenantEvent):
     name = 'incall_edited'
     routing_key_fmt = 'config.incalls.edited'
 
-    def __init__(self, incall_id: int, tenant_uuid: str):
+    def __init__(self, incall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': incall_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/incall_extension/event.py
+++ b/xivo_bus/resources/incall_extension/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class IncallExtensionAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class IncallExtensionAssociatedEvent(TenantEvent):
         self,
         incall_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'incall_id': incall_id,
@@ -33,7 +34,7 @@ class IncallExtensionDissociatedEvent(TenantEvent):
         self,
         incall_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'incall_id': incall_id,

--- a/xivo_bus/resources/incall_extension/event.py
+++ b/xivo_bus/resources/incall_extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class IncallExtensionAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class IncallExtensionAssociatedEvent(TenantEvent):
         self,
         incall_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'incall_id': incall_id,
@@ -34,7 +32,7 @@ class IncallExtensionDissociatedEvent(TenantEvent):
         self,
         incall_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'incall_id': incall_id,

--- a/xivo_bus/resources/incall_extension/event.py
+++ b/xivo_bus/resources/incall_extension/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class IncallExtensionAssociatedEvent(TenantEvent):
     name = 'incall_extension_associated'
     routing_key_fmt = 'config.incalls.extensions.updated'
 
-    def __init__(self, incall_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        incall_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'incall_id': incall_id,
             'extension_id': extension_id,
@@ -22,7 +29,12 @@ class IncallExtensionDissociatedEvent(TenantEvent):
     name = 'incall_extension_dissociated'
     routing_key_fmt = 'config.incalls.extensions.deleted'
 
-    def __init__(self, incall_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        incall_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'incall_id': incall_id,
             'extension_id': extension_id,

--- a/xivo_bus/resources/incall_schedule/event.py
+++ b/xivo_bus/resources/incall_schedule/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class IncallScheduleAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class IncallScheduleAssociatedEvent(TenantEvent):
         self,
         incall_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'incall_id': incall_id,
@@ -34,7 +32,7 @@ class IncallScheduleDissociatedEvent(TenantEvent):
         self,
         incall_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'incall_id': incall_id,

--- a/xivo_bus/resources/incall_schedule/event.py
+++ b/xivo_bus/resources/incall_schedule/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class IncallScheduleAssociatedEvent(TenantEvent):
     name = 'incall_schedule_associated'
     routing_key_fmt = 'config.incalls.schedules.updated'
 
-    def __init__(self, incall_id: int, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        incall_id: int,
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'incall_id': incall_id,
             'schedule_id': schedule_id,
@@ -22,7 +29,12 @@ class IncallScheduleDissociatedEvent(TenantEvent):
     name = 'incall_schedule_dissociated'
     routing_key_fmt = 'config.incalls.schedules.deleted'
 
-    def __init__(self, incall_id: int, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        incall_id: int,
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'incall_id': incall_id,
             'schedule_id': schedule_id,

--- a/xivo_bus/resources/incall_schedule/event.py
+++ b/xivo_bus/resources/incall_schedule/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class IncallScheduleAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class IncallScheduleAssociatedEvent(TenantEvent):
         self,
         incall_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'incall_id': incall_id,
@@ -33,7 +34,7 @@ class IncallScheduleDissociatedEvent(TenantEvent):
         self,
         incall_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'incall_id': incall_id,

--- a/xivo_bus/resources/ingress_http/event.py
+++ b/xivo_bus/resources/ingress_http/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import IngressHTTPDict
 
 
@@ -15,7 +16,7 @@ class IngressHTTPCreatedEvent(TenantEvent):
     def __init__(
         self,
         ingress_http: IngressHTTPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(ingress_http, tenant_uuid)
 
@@ -28,7 +29,7 @@ class IngressHTTPDeletedEvent(TenantEvent):
     def __init__(
         self,
         ingress_http: IngressHTTPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(ingress_http, tenant_uuid)
 
@@ -41,6 +42,6 @@ class IngressHTTPEditedEvent(TenantEvent):
     def __init__(
         self,
         ingress_http: IngressHTTPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(ingress_http, tenant_uuid)

--- a/xivo_bus/resources/ingress_http/event.py
+++ b/xivo_bus/resources/ingress_http/event.py
@@ -1,5 +1,7 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import IngressHTTPDict
@@ -10,7 +12,11 @@ class IngressHTTPCreatedEvent(TenantEvent):
     name = 'ingress_http_created'
     routing_key_fmt = 'config.ingresses.http.created'
 
-    def __init__(self, ingress_http: IngressHTTPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        ingress_http: IngressHTTPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(ingress_http, tenant_uuid)
 
 
@@ -19,7 +25,11 @@ class IngressHTTPDeletedEvent(TenantEvent):
     name = 'ingress_http_deleted'
     routing_key_fmt = 'config.ingresses.http.deleted'
 
-    def __init__(self, ingress_http: IngressHTTPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        ingress_http: IngressHTTPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(ingress_http, tenant_uuid)
 
 
@@ -28,5 +38,9 @@ class IngressHTTPEditedEvent(TenantEvent):
     name = 'ingress_http_edited'
     routing_key_fmt = 'config.ingresses.http.edited'
 
-    def __init__(self, ingress_http: IngressHTTPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        ingress_http: IngressHTTPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(ingress_http, tenant_uuid)

--- a/xivo_bus/resources/ingress_http/event.py
+++ b/xivo_bus/resources/ingress_http/event.py
@@ -1,10 +1,8 @@
 # Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import IngressHTTPDict
 
 
@@ -16,7 +14,7 @@ class IngressHTTPCreatedEvent(TenantEvent):
     def __init__(
         self,
         ingress_http: IngressHTTPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(ingress_http, tenant_uuid)
 
@@ -29,7 +27,7 @@ class IngressHTTPDeletedEvent(TenantEvent):
     def __init__(
         self,
         ingress_http: IngressHTTPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(ingress_http, tenant_uuid)
 
@@ -42,6 +40,6 @@ class IngressHTTPEditedEvent(TenantEvent):
     def __init__(
         self,
         ingress_http: IngressHTTPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(ingress_http, tenant_uuid)

--- a/xivo_bus/resources/ingress_http/types.py
+++ b/xivo_bus/resources/ingress_http/types.py
@@ -1,12 +1,12 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class IngressHTTPDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     uri: str

--- a/xivo_bus/resources/ingress_http/types.py
+++ b/xivo_bus/resources/ingress_http/types.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class IngressHTTPDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     uri: str

--- a/xivo_bus/resources/ingress_http/types.py
+++ b/xivo_bus/resources/ingress_http/types.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class IngressHTTPDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     uri: str

--- a/xivo_bus/resources/ivr/event.py
+++ b/xivo_bus/resources/ivr/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class IVRCreatedEvent(TenantEvent):
@@ -11,7 +12,7 @@ class IVRCreatedEvent(TenantEvent):
     name = 'ivr_created'
     routing_key_fmt = 'config.ivr.created'
 
-    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)
 
@@ -21,7 +22,7 @@ class IVRDeletedEvent(TenantEvent):
     name = 'ivr_deleted'
     routing_key_fmt = 'config.ivr.deleted'
 
-    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)
 
@@ -31,6 +32,6 @@ class IVREditedEvent(TenantEvent):
     name = 'ivr_edited'
     routing_key_fmt = 'config.ivr.edited'
 
-    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/ivr/event.py
+++ b/xivo_bus/resources/ivr/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,7 @@ class IVRCreatedEvent(TenantEvent):
     name = 'ivr_created'
     routing_key_fmt = 'config.ivr.created'
 
-    def __init__(self, ivr_id: int, tenant_uuid: str):
+    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +21,7 @@ class IVRDeletedEvent(TenantEvent):
     name = 'ivr_deleted'
     routing_key_fmt = 'config.ivr.deleted'
 
-    def __init__(self, ivr_id: int, tenant_uuid: str):
+    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +31,6 @@ class IVREditedEvent(TenantEvent):
     name = 'ivr_edited'
     routing_key_fmt = 'config.ivr.edited'
 
-    def __init__(self, ivr_id: int, tenant_uuid: str):
+    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/ivr/event.py
+++ b/xivo_bus/resources/ivr/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class IVRCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class IVRCreatedEvent(TenantEvent):
     name = 'ivr_created'
     routing_key_fmt = 'config.ivr.created'
 
-    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, ivr_id: int, tenant_uuid: UUIDStr):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class IVRDeletedEvent(TenantEvent):
     name = 'ivr_deleted'
     routing_key_fmt = 'config.ivr.deleted'
 
-    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, ivr_id: int, tenant_uuid: UUIDStr):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class IVREditedEvent(TenantEvent):
     name = 'ivr_edited'
     routing_key_fmt = 'config.ivr.edited'
 
-    def __init__(self, ivr_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, ivr_id: int, tenant_uuid: UUIDStr):
         content = {'id': ivr_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line/event.py
+++ b/xivo_bus/resources/line/event.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import LineDict
@@ -10,7 +12,7 @@ class LineCreatedEvent(TenantEvent):
     name = 'line_created'
     routing_key_fmt = 'config.line.created'
 
-    def __init__(self, line: LineDict, tenant_uuid: str):
+    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(line, tenant_uuid)
 
 
@@ -19,7 +21,7 @@ class LineDeletedEvent(TenantEvent):
     name = 'line_deleted'
     routing_key_fmt = 'config.line.deleted'
 
-    def __init__(self, line: LineDict, tenant_uuid: str):
+    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(line, tenant_uuid)
 
 
@@ -28,7 +30,7 @@ class LineEditedEvent(TenantEvent):
     name = 'line_edited'
     routing_key_fmt = 'config.line.edited'
 
-    def __init__(self, line: LineDict, tenant_uuid: str):
+    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(line, tenant_uuid)
 
 
@@ -44,7 +46,7 @@ class LineStatusUpdatedEvent(TenantEvent):
         endpoint_name: str,
         endpoint_registered: bool,
         endpoint_current_call_count: int,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'id': line_id,

--- a/xivo_bus/resources/line/event.py
+++ b/xivo_bus/resources/line/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import LineDict
 
 
@@ -12,7 +13,7 @@ class LineCreatedEvent(TenantEvent):
     name = 'line_created'
     routing_key_fmt = 'config.line.created'
 
-    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(line, tenant_uuid)
 
 
@@ -21,7 +22,7 @@ class LineDeletedEvent(TenantEvent):
     name = 'line_deleted'
     routing_key_fmt = 'config.line.deleted'
 
-    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(line, tenant_uuid)
 
 
@@ -30,7 +31,7 @@ class LineEditedEvent(TenantEvent):
     name = 'line_edited'
     routing_key_fmt = 'config.line.edited'
 
-    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(line, tenant_uuid)
 
 
@@ -46,7 +47,7 @@ class LineStatusUpdatedEvent(TenantEvent):
         endpoint_name: str,
         endpoint_registered: bool,
         endpoint_current_call_count: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': line_id,

--- a/xivo_bus/resources/line/event.py
+++ b/xivo_bus/resources/line/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import LineDict
 
 
@@ -13,7 +11,7 @@ class LineCreatedEvent(TenantEvent):
     name = 'line_created'
     routing_key_fmt = 'config.line.created'
 
-    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, line: LineDict, tenant_uuid: UUIDStr):
         super().__init__(line, tenant_uuid)
 
 
@@ -22,7 +20,7 @@ class LineDeletedEvent(TenantEvent):
     name = 'line_deleted'
     routing_key_fmt = 'config.line.deleted'
 
-    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, line: LineDict, tenant_uuid: UUIDStr):
         super().__init__(line, tenant_uuid)
 
 
@@ -31,7 +29,7 @@ class LineEditedEvent(TenantEvent):
     name = 'line_edited'
     routing_key_fmt = 'config.line.edited'
 
-    def __init__(self, line: LineDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, line: LineDict, tenant_uuid: UUIDStr):
         super().__init__(line, tenant_uuid)
 
 
@@ -47,7 +45,7 @@ class LineStatusUpdatedEvent(TenantEvent):
         endpoint_name: str,
         endpoint_registered: bool,
         endpoint_current_call_count: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'id': line_id,

--- a/xivo_bus/resources/line/types.py
+++ b/xivo_bus/resources/line/types.py
@@ -1,13 +1,13 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class LineDict(TypedDict, total=False):
     id: int
     protocol: str
     name: str
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]

--- a/xivo_bus/resources/line/types.py
+++ b/xivo_bus/resources/line/types.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class LineDict(TypedDict, total=False):
     id: int
     protocol: str
     name: str
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]

--- a/xivo_bus/resources/line/types.py
+++ b/xivo_bus/resources/line/types.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class LineDict(TypedDict, total=False):
     id: int
     protocol: str
     name: str
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr

--- a/xivo_bus/resources/line_application/event.py
+++ b/xivo_bus/resources/line_application/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import ApplicationDict, LineDict
 
 
@@ -16,7 +17,7 @@ class LineApplicationAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'application': application}
         super().__init__(content, tenant_uuid)
@@ -31,7 +32,7 @@ class LineApplicationDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'application': application}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_application/event.py
+++ b/xivo_bus/resources/line_application/event.py
@@ -1,10 +1,8 @@
 # Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import ApplicationDict, LineDict
 
 
@@ -17,7 +15,7 @@ class LineApplicationAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'application': application}
         super().__init__(content, tenant_uuid)
@@ -32,7 +30,7 @@ class LineApplicationDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         application: ApplicationDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'application': application}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_application/event.py
+++ b/xivo_bus/resources/line_application/event.py
@@ -1,5 +1,7 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import ApplicationDict, LineDict
@@ -10,7 +12,12 @@ class LineApplicationAssociatedEvent(TenantEvent):
     name = 'line_application_associated'
     routing_key_fmt = 'config.lines.{line[id]}.applications.{application[uuid]}.updated'
 
-    def __init__(self, line: LineDict, application: ApplicationDict, tenant_uuid: str):
+    def __init__(
+        self,
+        line: LineDict,
+        application: ApplicationDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line': line, 'application': application}
         super().__init__(content, tenant_uuid)
 
@@ -20,6 +27,11 @@ class LineApplicationDissociatedEvent(TenantEvent):
     name = 'line_application_dissociated'
     routing_key_fmt = 'config.lines.{line[id]}.applications.{application[uuid]}.deleted'
 
-    def __init__(self, line: LineDict, application: ApplicationDict, tenant_uuid: str):
+    def __init__(
+        self,
+        line: LineDict,
+        application: ApplicationDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line': line, 'application': application}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_application/types.py
+++ b/xivo_bus/resources/line_application/types.py
@@ -1,17 +1,17 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class ApplicationDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
 
 
 class LineEndpointSCCPDict(TypedDict, total=False):

--- a/xivo_bus/resources/line_application/types.py
+++ b/xivo_bus/resources/line_application/types.py
@@ -3,17 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ApplicationDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
 
 
 class LineEndpointSCCPDict(TypedDict, total=False):

--- a/xivo_bus/resources/line_application/types.py
+++ b/xivo_bus/resources/line_application/types.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class ApplicationDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
 
 
 class LineEndpointSCCPDict(TypedDict, total=False):

--- a/xivo_bus/resources/line_device/event.py
+++ b/xivo_bus/resources/line_device/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import DeviceDict, LineDict
 
 
@@ -16,7 +17,7 @@ class LineDeviceAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         device: DeviceDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'device': device}
         super().__init__(content, tenant_uuid)
@@ -31,7 +32,7 @@ class LineDeviceDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         device: DeviceDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'device': device}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_device/event.py
+++ b/xivo_bus/resources/line_device/event.py
@@ -1,5 +1,7 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import DeviceDict, LineDict
@@ -10,7 +12,12 @@ class LineDeviceAssociatedEvent(TenantEvent):
     name = 'line_device_associated'
     routing_key_fmt = 'config.lines.{line[id]}.devices.{device[id]}.updated'
 
-    def __init__(self, line: LineDict, device: DeviceDict, tenant_uuid: str):
+    def __init__(
+        self,
+        line: LineDict,
+        device: DeviceDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line': line, 'device': device}
         super().__init__(content, tenant_uuid)
 
@@ -20,6 +27,11 @@ class LineDeviceDissociatedEvent(TenantEvent):
     name = 'line_device_dissociated'
     routing_key_fmt = 'config.lines.{line[id]}.devices.{device[id]}.deleted'
 
-    def __init__(self, line: LineDict, device: DeviceDict, tenant_uuid: str):
+    def __init__(
+        self,
+        line: LineDict,
+        device: DeviceDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line': line, 'device': device}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_device/event.py
+++ b/xivo_bus/resources/line_device/event.py
@@ -1,10 +1,8 @@
 # Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import DeviceDict, LineDict
 
 
@@ -17,7 +15,7 @@ class LineDeviceAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         device: DeviceDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'device': device}
         super().__init__(content, tenant_uuid)
@@ -32,7 +30,7 @@ class LineDeviceDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         device: DeviceDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'device': device}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_device/types.py
+++ b/xivo_bus/resources/line_device/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class DeviceDict(TypedDict, total=False):
@@ -13,7 +13,7 @@ class DeviceDict(TypedDict, total=False):
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
 
 
 class LineEndpointSCCPDict(TypedDict, total=False):

--- a/xivo_bus/resources/line_device/types.py
+++ b/xivo_bus/resources/line_device/types.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class DeviceDict(TypedDict, total=False):
     id: str
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
 
 
 class LineEndpointSCCPDict(TypedDict, total=False):

--- a/xivo_bus/resources/line_device/types.py
+++ b/xivo_bus/resources/line_device/types.py
@@ -1,9 +1,9 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class DeviceDict(TypedDict, total=False):
@@ -11,7 +11,7 @@ class DeviceDict(TypedDict, total=False):
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
 
 
 class LineEndpointSCCPDict(TypedDict, total=False):

--- a/xivo_bus/resources/line_endpoint/event.py
+++ b/xivo_bus/resources/line_endpoint/event.py
@@ -1,10 +1,8 @@
 # Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import (
     LineDict,
     LineEndpointCustomDict,
@@ -24,7 +22,7 @@ class LineEndpointSIPAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         sip: LineEndpointSIPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'endpoint_sip': sip}
         super().__init__(content, tenant_uuid)
@@ -41,7 +39,7 @@ class LineEndpointSIPDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         sip: LineEndpointSIPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'endpoint_sip': sip}
         super().__init__(content, tenant_uuid)
@@ -58,7 +56,7 @@ class LineEndpointSCCPAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         sccp: LineEndpointSCCPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'endpoint_sccp': sccp}
         super().__init__(content, tenant_uuid)
@@ -75,7 +73,7 @@ class LineEndpointSCCPDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         sccp: LineEndpointSCCPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'endpoint_sccp': sccp}
         super().__init__(content, tenant_uuid)
@@ -92,7 +90,7 @@ class LineEndpointCustomAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         custom: LineEndpointCustomDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'endpoint_custom': custom}
         super().__init__(content, tenant_uuid)
@@ -109,7 +107,7 @@ class LineEndpointCustomDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         custom: LineEndpointCustomDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line': line, 'endpoint_custom': custom}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_endpoint/event.py
+++ b/xivo_bus/resources/line_endpoint/event.py
@@ -1,5 +1,7 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import (
@@ -17,7 +19,12 @@ class LineEndpointSIPAssociatedEvent(TenantEvent):
         'config.lines.{line[id]}.endpoints.sip.{endpoint_sip[uuid]}.updated'
     )
 
-    def __init__(self, line: LineDict, sip: LineEndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        line: LineDict,
+        sip: LineEndpointSIPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line': line, 'endpoint_sip': sip}
         super().__init__(content, tenant_uuid)
 
@@ -29,7 +36,12 @@ class LineEndpointSIPDissociatedEvent(TenantEvent):
         'config.lines.{line[id]}.endpoints.sip.{endpoint_sip[uuid]}.deleted'
     )
 
-    def __init__(self, line: LineDict, sip: LineEndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        line: LineDict,
+        sip: LineEndpointSIPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line': line, 'endpoint_sip': sip}
         super().__init__(content, tenant_uuid)
 
@@ -41,7 +53,12 @@ class LineEndpointSCCPAssociatedEvent(TenantEvent):
         'config.lines.{line[id]}.endpoints.sccp.{endpoint_sccp[id]}.updated'
     )
 
-    def __init__(self, line: LineDict, sccp: LineEndpointSCCPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        line: LineDict,
+        sccp: LineEndpointSCCPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line': line, 'endpoint_sccp': sccp}
         super().__init__(content, tenant_uuid)
 
@@ -53,7 +70,12 @@ class LineEndpointSCCPDissociatedEvent(TenantEvent):
         'config.lines.{line[id]}.endpoints.sccp.{endpoint_sccp[id]}.deleted'
     )
 
-    def __init__(self, line: LineDict, sccp: LineEndpointSCCPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        line: LineDict,
+        sccp: LineEndpointSCCPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line': line, 'endpoint_sccp': sccp}
         super().__init__(content, tenant_uuid)
 
@@ -66,7 +88,10 @@ class LineEndpointCustomAssociatedEvent(TenantEvent):
     )
 
     def __init__(
-        self, line: LineDict, custom: LineEndpointCustomDict, tenant_uuid: str
+        self,
+        line: LineDict,
+        custom: LineEndpointCustomDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'line': line, 'endpoint_custom': custom}
         super().__init__(content, tenant_uuid)
@@ -80,7 +105,10 @@ class LineEndpointCustomDissociatedEvent(TenantEvent):
     )
 
     def __init__(
-        self, line: LineDict, custom: LineEndpointCustomDict, tenant_uuid: str
+        self,
+        line: LineDict,
+        custom: LineEndpointCustomDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {'line': line, 'endpoint_custom': custom}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_endpoint/event.py
+++ b/xivo_bus/resources/line_endpoint/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import (
     LineDict,
     LineEndpointCustomDict,
@@ -23,7 +24,7 @@ class LineEndpointSIPAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         sip: LineEndpointSIPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'endpoint_sip': sip}
         super().__init__(content, tenant_uuid)
@@ -40,7 +41,7 @@ class LineEndpointSIPDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         sip: LineEndpointSIPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'endpoint_sip': sip}
         super().__init__(content, tenant_uuid)
@@ -57,7 +58,7 @@ class LineEndpointSCCPAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         sccp: LineEndpointSCCPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'endpoint_sccp': sccp}
         super().__init__(content, tenant_uuid)
@@ -74,7 +75,7 @@ class LineEndpointSCCPDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         sccp: LineEndpointSCCPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'endpoint_sccp': sccp}
         super().__init__(content, tenant_uuid)
@@ -91,7 +92,7 @@ class LineEndpointCustomAssociatedEvent(TenantEvent):
         self,
         line: LineDict,
         custom: LineEndpointCustomDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'endpoint_custom': custom}
         super().__init__(content, tenant_uuid)
@@ -108,7 +109,7 @@ class LineEndpointCustomDissociatedEvent(TenantEvent):
         self,
         line: LineDict,
         custom: LineEndpointCustomDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line': line, 'endpoint_custom': custom}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_endpoint/types.py
+++ b/xivo_bus/resources/line_endpoint/types.py
@@ -1,9 +1,9 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class EndpointSIPAuthSectionOptionsDict(TypedDict, total=False):
@@ -11,8 +11,8 @@ class EndpointSIPAuthSectionOptionsDict(TypedDict, total=False):
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     label: str
     name: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict
@@ -20,16 +20,16 @@ class LineEndpointSIPDict(TypedDict, total=False):
 
 class LineEndpointSCCPDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
 
 
 class LineEndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     interface: str
 
 
 class LineDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     name: str

--- a/xivo_bus/resources/line_endpoint/types.py
+++ b/xivo_bus/resources/line_endpoint/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class EndpointSIPAuthSectionOptionsDict(TypedDict, total=False):
@@ -13,8 +13,8 @@ class EndpointSIPAuthSectionOptionsDict(TypedDict, total=False):
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     label: str
     name: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict
@@ -22,16 +22,16 @@ class LineEndpointSIPDict(TypedDict, total=False):
 
 class LineEndpointSCCPDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr
 
 
 class LineEndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr
     interface: str
 
 
 class LineDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr
     name: str

--- a/xivo_bus/resources/line_endpoint/types.py
+++ b/xivo_bus/resources/line_endpoint/types.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class EndpointSIPAuthSectionOptionsDict(TypedDict, total=False):
     username: str
 
 
 class LineEndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     label: str
     name: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict
@@ -20,16 +22,16 @@ class LineEndpointSIPDict(TypedDict, total=False):
 
 class LineEndpointSCCPDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
 
 
 class LineEndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
     interface: str
 
 
 class LineDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
     name: str

--- a/xivo_bus/resources/line_extension/event.py
+++ b/xivo_bus/resources/line_extension/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class LineExtensionAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class LineExtensionAssociatedEvent(TenantEvent):
         self,
         line_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line_id': line_id, 'extension_id': extension_id}
         super().__init__(content, tenant_uuid)
@@ -30,7 +31,7 @@ class LineExtensionDissociatedEvent(TenantEvent):
         self,
         line_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'line_id': line_id, 'extension_id': extension_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_extension/event.py
+++ b/xivo_bus/resources/line_extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class LineExtensionAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class LineExtensionAssociatedEvent(TenantEvent):
         self,
         line_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line_id': line_id, 'extension_id': extension_id}
         super().__init__(content, tenant_uuid)
@@ -31,7 +29,7 @@ class LineExtensionDissociatedEvent(TenantEvent):
         self,
         line_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'line_id': line_id, 'extension_id': extension_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/line_extension/event.py
+++ b/xivo_bus/resources/line_extension/event.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class LineExtensionAssociatedEvent(TenantEvent):
     name = 'line_extension_associated'
     routing_key_fmt = 'config.line_extension_associated.updated'
 
-    def __init__(self, line_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        line_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line_id': line_id, 'extension_id': extension_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,6 +26,11 @@ class LineExtensionDissociatedEvent(TenantEvent):
     name = 'line_extension_dissociated'
     routing_key_fmt = 'config.line_extension_associated.deleted'
 
-    def __init__(self, line_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        line_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'line_id': line_id, 'extension_id': extension_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/meeting/event.py
+++ b/xivo_bus/resources/meeting/event.py
@@ -4,10 +4,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated, Any
+from typing import Any
 
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import MeetingAuthorizationDict, MeetingDict, MeetingParticipantDict
 
 
@@ -15,7 +15,7 @@ class _MeetingMixin:
     def __init__(
         self,
         content: Mapping,
-        meeting_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
         *args: Any,
     ):
         super().__init__(content, *args)  # type: ignore[call-arg]
@@ -29,9 +29,7 @@ class MeetingCreatedEvent(_MeetingMixin, TenantEvent):
     name = 'meeting_created'
     routing_key_fmt = 'config.meetings.created'
 
-    def __init__(
-        self, meeting: MeetingDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, meeting: MeetingDict, tenant_uuid: UUIDStr):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
 
@@ -40,9 +38,7 @@ class MeetingDeletedEvent(_MeetingMixin, TenantEvent):
     name = 'meeting_deleted'
     routing_key_fmt = 'config.meetings.deleted'
 
-    def __init__(
-        self, meeting: MeetingDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, meeting: MeetingDict, tenant_uuid: UUIDStr):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
 
@@ -51,9 +47,7 @@ class MeetingEditedEvent(_MeetingMixin, TenantEvent):
     name = 'meeting_updated'
     routing_key_fmt = 'config.meetings.updated'
 
-    def __init__(
-        self, meeting: MeetingDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, meeting: MeetingDict, tenant_uuid: UUIDStr):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
 
@@ -66,7 +60,7 @@ class MeetingProgressEvent(_MeetingMixin, TenantEvent):
         self,
         meeting: MeetingDict,
         status: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = dict(meeting)
         content['status'] = status
@@ -82,8 +76,8 @@ class MeetingUserProgressEvent(_MeetingMixin, UserEvent):
         self,
         meeting: MeetingDict,
         status: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(meeting)
         content['status'] = status
@@ -99,8 +93,8 @@ class MeetingParticipantJoinedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid)
@@ -114,8 +108,8 @@ class MeetingParticipantLeftEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid)
@@ -130,9 +124,9 @@ class MeetingUserParticipantJoinedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -147,9 +141,9 @@ class MeetingUserParticipantLeftEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -163,8 +157,8 @@ class MeetingAuthorizationCreatedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -177,8 +171,8 @@ class MeetingAuthorizationDeletedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -191,8 +185,8 @@ class MeetingAuthorizationEditedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -206,9 +200,9 @@ class MeetingUserAuthorizationCreatedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -223,9 +217,9 @@ class MeetingUserAuthorizationDeletedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -240,9 +234,9 @@ class MeetingUserAuthorizationEditedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        meeting_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/meeting/event.py
+++ b/xivo_bus/resources/meeting/event.py
@@ -1,17 +1,22 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Annotated, Any
 
 from ..common.event import TenantEvent, UserEvent
 from .types import MeetingAuthorizationDict, MeetingDict, MeetingParticipantDict
 
 
 class _MeetingMixin:
-    def __init__(self, content: Mapping, meeting_uuid: str, *args: Any):
+    def __init__(
+        self,
+        content: Mapping,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        *args: Any,
+    ):
         super().__init__(content, *args)  # type: ignore[call-arg]
         if meeting_uuid is None:
             raise ValueError('meeting_uuid must have a value')
@@ -23,7 +28,9 @@ class MeetingCreatedEvent(_MeetingMixin, TenantEvent):
     name = 'meeting_created'
     routing_key_fmt = 'config.meetings.created'
 
-    def __init__(self, meeting: MeetingDict, tenant_uuid: str):
+    def __init__(
+        self, meeting: MeetingDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
 
@@ -32,7 +39,9 @@ class MeetingDeletedEvent(_MeetingMixin, TenantEvent):
     name = 'meeting_deleted'
     routing_key_fmt = 'config.meetings.deleted'
 
-    def __init__(self, meeting: MeetingDict, tenant_uuid: str):
+    def __init__(
+        self, meeting: MeetingDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
 
@@ -41,7 +50,9 @@ class MeetingEditedEvent(_MeetingMixin, TenantEvent):
     name = 'meeting_updated'
     routing_key_fmt = 'config.meetings.updated'
 
-    def __init__(self, meeting: MeetingDict, tenant_uuid: str):
+    def __init__(
+        self, meeting: MeetingDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
 
@@ -50,7 +61,12 @@ class MeetingProgressEvent(_MeetingMixin, TenantEvent):
     name = 'meeting_progress'
     routing_key_fmt = 'config.meetings.progress'
 
-    def __init__(self, meeting: MeetingDict, status: str, tenant_uuid: str):
+    def __init__(
+        self,
+        meeting: MeetingDict,
+        status: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = dict(meeting)
         content['status'] = status
         super().__init__(content, meeting['uuid'], tenant_uuid)
@@ -62,7 +78,11 @@ class MeetingUserProgressEvent(_MeetingMixin, UserEvent):
     routing_key_fmt = 'config.users.{user_uuid}.meetings.progress'
 
     def __init__(
-        self, meeting: MeetingDict, status: str, tenant_uuid: str, user_uuid: str
+        self,
+        meeting: MeetingDict,
+        status: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(meeting)
         content['status'] = status
@@ -76,7 +96,10 @@ class MeetingParticipantJoinedEvent(_MeetingMixin, TenantEvent):
     routing_key_fmt = 'meetings.{meeting_uuid}.participants.joined'
 
     def __init__(
-        self, participant: MeetingParticipantDict, meeting_uuid: str, tenant_uuid: str
+        self,
+        participant: MeetingParticipantDict,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid)
@@ -88,7 +111,10 @@ class MeetingParticipantLeftEvent(_MeetingMixin, TenantEvent):
     routing_key_fmt = 'meetings.{meeting_uuid}.participants.left'
 
     def __init__(
-        self, participant: MeetingParticipantDict, meeting_uuid: str, tenant_uuid: str
+        self,
+        participant: MeetingParticipantDict,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid)
@@ -103,9 +129,9 @@ class MeetingUserParticipantJoinedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -120,9 +146,9 @@ class MeetingUserParticipantLeftEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -136,8 +162,8 @@ class MeetingAuthorizationCreatedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: str,
-        tenant_uuid: str,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -150,8 +176,8 @@ class MeetingAuthorizationDeletedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: str,
-        tenant_uuid: str,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -164,8 +190,8 @@ class MeetingAuthorizationEditedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: str,
-        tenant_uuid: str,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -179,9 +205,9 @@ class MeetingUserAuthorizationCreatedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -196,9 +222,9 @@ class MeetingUserAuthorizationDeletedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -213,9 +239,9 @@ class MeetingUserAuthorizationEditedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/meeting/event.py
+++ b/xivo_bus/resources/meeting/event.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Annotated, Any
 
 from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 from .types import MeetingAuthorizationDict, MeetingDict, MeetingParticipantDict
 
 
@@ -14,7 +15,7 @@ class _MeetingMixin:
     def __init__(
         self,
         content: Mapping,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
         *args: Any,
     ):
         super().__init__(content, *args)  # type: ignore[call-arg]
@@ -29,7 +30,7 @@ class MeetingCreatedEvent(_MeetingMixin, TenantEvent):
     routing_key_fmt = 'config.meetings.created'
 
     def __init__(
-        self, meeting: MeetingDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, meeting: MeetingDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
@@ -40,7 +41,7 @@ class MeetingDeletedEvent(_MeetingMixin, TenantEvent):
     routing_key_fmt = 'config.meetings.deleted'
 
     def __init__(
-        self, meeting: MeetingDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, meeting: MeetingDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
@@ -51,7 +52,7 @@ class MeetingEditedEvent(_MeetingMixin, TenantEvent):
     routing_key_fmt = 'config.meetings.updated'
 
     def __init__(
-        self, meeting: MeetingDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, meeting: MeetingDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(meeting, meeting['uuid'], tenant_uuid)
 
@@ -65,7 +66,7 @@ class MeetingProgressEvent(_MeetingMixin, TenantEvent):
         self,
         meeting: MeetingDict,
         status: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(meeting)
         content['status'] = status
@@ -81,8 +82,8 @@ class MeetingUserProgressEvent(_MeetingMixin, UserEvent):
         self,
         meeting: MeetingDict,
         status: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(meeting)
         content['status'] = status
@@ -98,8 +99,8 @@ class MeetingParticipantJoinedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid)
@@ -113,8 +114,8 @@ class MeetingParticipantLeftEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid)
@@ -129,9 +130,9 @@ class MeetingUserParticipantJoinedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -146,9 +147,9 @@ class MeetingUserParticipantLeftEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         participant: MeetingParticipantDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(participant, meeting_uuid=meeting_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -162,8 +163,8 @@ class MeetingAuthorizationCreatedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -176,8 +177,8 @@ class MeetingAuthorizationDeletedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -190,8 +191,8 @@ class MeetingAuthorizationEditedEvent(_MeetingMixin, TenantEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(meeting_authorization, meeting_uuid, tenant_uuid)
 
@@ -205,9 +206,9 @@ class MeetingUserAuthorizationCreatedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -222,9 +223,9 @@ class MeetingUserAuthorizationDeletedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)
@@ -239,9 +240,9 @@ class MeetingUserAuthorizationEditedEvent(_MeetingMixin, UserEvent):
     def __init__(
         self,
         meeting_authorization: MeetingAuthorizationDict,
-        meeting_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        meeting_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = dict(meeting_authorization, user_uuid=user_uuid)
         super().__init__(content, meeting_uuid, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/meeting/types.py
+++ b/xivo_bus/resources/meeting/types.py
@@ -3,21 +3,21 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class MeetingDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     name: str
-    owner_uuids: list[str]
+    owner_uuids: Annotated[list[str], {'format': 'uuid'}]
     ingress_http_uri: str
     guest_sip_authorization: str | None  # b64 encoded
 
 
 class MeetingAuthorizationDict(TypedDict, total=False):
-    uuid: str
-    meeting_uuid: str
-    guest_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    meeting_uuid: Annotated[str, {'format': 'uuid'}]
+    guest_uuid: Annotated[str, {'format': 'uuid'}]
     guest_name: str
     status: str
     creation_time: str
@@ -28,4 +28,4 @@ class MeetingParticipantDict(TypedDict, total=False):
     caller_id_name: str
     caller_id_number: str
     call_id: str
-    user_uuid: str | None
+    user_uuid: Annotated[str | None, {'format': 'uuid'}]

--- a/xivo_bus/resources/meeting/types.py
+++ b/xivo_bus/resources/meeting/types.py
@@ -3,23 +3,23 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class MeetingDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     name: str
-    owner_uuids: Annotated[list[str], Format('uuid')]
+    owner_uuids: list[UUIDStr]
     ingress_http_uri: str
     guest_sip_authorization: str | None  # b64 encoded
 
 
 class MeetingAuthorizationDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    meeting_uuid: Annotated[str, Format('uuid')]
-    guest_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    meeting_uuid: UUIDStr
+    guest_uuid: UUIDStr
     guest_name: str
     status: str
     creation_time: str
@@ -30,4 +30,4 @@ class MeetingParticipantDict(TypedDict, total=False):
     caller_id_name: str
     caller_id_number: str
     call_id: str
-    user_uuid: Annotated[str | None, Format('uuid')]
+    user_uuid: UUIDStr | None

--- a/xivo_bus/resources/meeting/types.py
+++ b/xivo_bus/resources/meeting/types.py
@@ -5,19 +5,21 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class MeetingDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     name: str
-    owner_uuids: Annotated[list[str], {'format': 'uuid'}]
+    owner_uuids: Annotated[list[str], Format('uuid')]
     ingress_http_uri: str
     guest_sip_authorization: str | None  # b64 encoded
 
 
 class MeetingAuthorizationDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    meeting_uuid: Annotated[str, {'format': 'uuid'}]
-    guest_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    meeting_uuid: Annotated[str, Format('uuid')]
+    guest_uuid: Annotated[str, Format('uuid')]
     guest_name: str
     status: str
     creation_time: str
@@ -28,4 +30,4 @@ class MeetingParticipantDict(TypedDict, total=False):
     caller_id_name: str
     caller_id_number: str
     call_id: str
-    user_uuid: Annotated[str | None, {'format': 'uuid'}]
+    user_uuid: Annotated[str | None, Format('uuid')]

--- a/xivo_bus/resources/moh/event.py
+++ b/xivo_bus/resources/moh/event.py
@@ -1,5 +1,7 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import MOHDict
@@ -10,7 +12,7 @@ class MOHCreatedEvent(TenantEvent):
     name = 'moh_created'
     routing_key_fmt = 'config.moh.created'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: str):
+    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(moh, tenant_uuid)
 
 
@@ -19,7 +21,7 @@ class MOHDeletedEvent(TenantEvent):
     name = 'moh_deleted'
     routing_key_fmt = 'config.moh.deleted'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: str):
+    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(moh, tenant_uuid)
 
 
@@ -28,5 +30,5 @@ class MOHEditedEvent(TenantEvent):
     name = 'moh_edited'
     routing_key_fmt = 'config.moh.edited'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: str):
+    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         super().__init__(moh, tenant_uuid)

--- a/xivo_bus/resources/moh/event.py
+++ b/xivo_bus/resources/moh/event.py
@@ -1,10 +1,8 @@
 # Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import MOHDict
 
 
@@ -13,7 +11,7 @@ class MOHCreatedEvent(TenantEvent):
     name = 'moh_created'
     routing_key_fmt = 'config.moh.created'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, moh: MOHDict, tenant_uuid: UUIDStr):
         super().__init__(moh, tenant_uuid)
 
 
@@ -22,7 +20,7 @@ class MOHDeletedEvent(TenantEvent):
     name = 'moh_deleted'
     routing_key_fmt = 'config.moh.deleted'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, moh: MOHDict, tenant_uuid: UUIDStr):
         super().__init__(moh, tenant_uuid)
 
 
@@ -31,5 +29,5 @@ class MOHEditedEvent(TenantEvent):
     name = 'moh_edited'
     routing_key_fmt = 'config.moh.edited'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, moh: MOHDict, tenant_uuid: UUIDStr):
         super().__init__(moh, tenant_uuid)

--- a/xivo_bus/resources/moh/event.py
+++ b/xivo_bus/resources/moh/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import MOHDict
 
 
@@ -12,7 +13,7 @@ class MOHCreatedEvent(TenantEvent):
     name = 'moh_created'
     routing_key_fmt = 'config.moh.created'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(moh, tenant_uuid)
 
 
@@ -21,7 +22,7 @@ class MOHDeletedEvent(TenantEvent):
     name = 'moh_deleted'
     routing_key_fmt = 'config.moh.deleted'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(moh, tenant_uuid)
 
 
@@ -30,5 +31,5 @@ class MOHEditedEvent(TenantEvent):
     name = 'moh_edited'
     routing_key_fmt = 'config.moh.edited'
 
-    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, moh: MOHDict, tenant_uuid: Annotated[str, Format('uuid')]):
         super().__init__(moh, tenant_uuid)

--- a/xivo_bus/resources/moh/types.py
+++ b/xivo_bus/resources/moh/types.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class MOHDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     name: str

--- a/xivo_bus/resources/moh/types.py
+++ b/xivo_bus/resources/moh/types.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class MOHDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     name: str

--- a/xivo_bus/resources/moh/types.py
+++ b/xivo_bus/resources/moh/types.py
@@ -1,12 +1,12 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class MOHDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     name: str

--- a/xivo_bus/resources/outcall/event.py
+++ b/xivo_bus/resources/outcall/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class OutcallCreatedEvent(TenantEvent):
@@ -11,9 +12,7 @@ class OutcallCreatedEvent(TenantEvent):
     name = 'outcall_created'
     routing_key_fmt = 'config.outcalls.created'
 
-    def __init__(
-        self, outcall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, outcall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)
 
@@ -23,9 +22,7 @@ class OutcallDeletedEvent(TenantEvent):
     name = 'outcall_deleted'
     routing_key_fmt = 'config.outcalls.deleted'
 
-    def __init__(
-        self, outcall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, outcall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)
 
@@ -35,8 +32,6 @@ class OutcallEditedEvent(TenantEvent):
     name = 'outcall_edited'
     routing_key_fmt = 'config.outcalls.edited'
 
-    def __init__(
-        self, outcall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, outcall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/outcall/event.py
+++ b/xivo_bus/resources/outcall/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class OutcallCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class OutcallCreatedEvent(TenantEvent):
     name = 'outcall_created'
     routing_key_fmt = 'config.outcalls.created'
 
-    def __init__(self, outcall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, outcall_id: int, tenant_uuid: UUIDStr):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class OutcallDeletedEvent(TenantEvent):
     name = 'outcall_deleted'
     routing_key_fmt = 'config.outcalls.deleted'
 
-    def __init__(self, outcall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, outcall_id: int, tenant_uuid: UUIDStr):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class OutcallEditedEvent(TenantEvent):
     name = 'outcall_edited'
     routing_key_fmt = 'config.outcalls.edited'
 
-    def __init__(self, outcall_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, outcall_id: int, tenant_uuid: UUIDStr):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/outcall/event.py
+++ b/xivo_bus/resources/outcall/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class OutcallCreatedEvent(TenantEvent):
     name = 'outcall_created'
     routing_key_fmt = 'config.outcalls.created'
 
-    def __init__(self, outcall_id: int, tenant_uuid: str):
+    def __init__(
+        self, outcall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +23,9 @@ class OutcallDeletedEvent(TenantEvent):
     name = 'outcall_deleted'
     routing_key_fmt = 'config.outcalls.deleted'
 
-    def __init__(self, outcall_id: int, tenant_uuid: str):
+    def __init__(
+        self, outcall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +35,8 @@ class OutcallEditedEvent(TenantEvent):
     name = 'outcall_edited'
     routing_key_fmt = 'config.outcalls.edited'
 
-    def __init__(self, outcall_id: int, tenant_uuid: str):
+    def __init__(
+        self, outcall_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': outcall_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/outcall_call_permission/event.py
+++ b/xivo_bus/resources/outcall_call_permission/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class OutcallCallPermissionAssociatedEvent(TenantEvent):
     name = 'outcall_call_permission_associated'
     routing_key_fmt = 'config.outcalls.{outcall_id}.callpermissions.updated'
 
-    def __init__(self, outcall_id: int, call_permission_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        outcall_id: int,
+        call_permission_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'outcall_id': outcall_id,
             'call_permission_id': call_permission_id,
@@ -22,7 +29,12 @@ class OutcallCallPermissionDissociatedEvent(TenantEvent):
     name = 'outcall_call_permission_dissociated'
     routing_key_fmt = 'config.outcalls.{outcall_id}.callpermissions.deleted'
 
-    def __init__(self, outcall_id: int, call_permission_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        outcall_id: int,
+        call_permission_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'outcall_id': outcall_id,
             'call_permission_id': call_permission_id,

--- a/xivo_bus/resources/outcall_call_permission/event.py
+++ b/xivo_bus/resources/outcall_call_permission/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class OutcallCallPermissionAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class OutcallCallPermissionAssociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'outcall_id': outcall_id,
@@ -34,7 +32,7 @@ class OutcallCallPermissionDissociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'outcall_id': outcall_id,

--- a/xivo_bus/resources/outcall_call_permission/event.py
+++ b/xivo_bus/resources/outcall_call_permission/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class OutcallCallPermissionAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class OutcallCallPermissionAssociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'outcall_id': outcall_id,
@@ -33,7 +34,7 @@ class OutcallCallPermissionDissociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'outcall_id': outcall_id,

--- a/xivo_bus/resources/outcall_extension/event.py
+++ b/xivo_bus/resources/outcall_extension/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class OutcallExtensionAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class OutcallExtensionAssociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'outcall_id': outcall_id,
@@ -33,7 +34,7 @@ class OutcallExtensionDissociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'outcall_id': outcall_id,

--- a/xivo_bus/resources/outcall_extension/event.py
+++ b/xivo_bus/resources/outcall_extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class OutcallExtensionAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class OutcallExtensionAssociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'outcall_id': outcall_id,
@@ -34,7 +32,7 @@ class OutcallExtensionDissociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'outcall_id': outcall_id,

--- a/xivo_bus/resources/outcall_extension/event.py
+++ b/xivo_bus/resources/outcall_extension/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class OutcallExtensionAssociatedEvent(TenantEvent):
     name = 'outcall_extension_associated'
     routing_key_fmt = 'config.outcalls.extensions.updated'
 
-    def __init__(self, outcall_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        outcall_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'outcall_id': outcall_id,
             'extension_id': extension_id,
@@ -22,7 +29,12 @@ class OutcallExtensionDissociatedEvent(TenantEvent):
     name = 'outcall_extension_dissociated'
     routing_key_fmt = 'config.outcalls.extensions.deleted'
 
-    def __init__(self, outcall_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        outcall_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'outcall_id': outcall_id,
             'extension_id': extension_id,

--- a/xivo_bus/resources/outcall_schedule/event.py
+++ b/xivo_bus/resources/outcall_schedule/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class OutcallScheduleAssociatedEvent(TenantEvent):
     name = 'outcall_schedule_associated'
     routing_key_fmt = 'config.outcalls.schedules.updated'
 
-    def __init__(self, outcall_id: int, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        outcall_id: int,
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'outcall_id': outcall_id,
             'schedule_id': schedule_id,
@@ -22,7 +29,12 @@ class OutcallScheduleDissociatedEvent(TenantEvent):
     name = 'outcall_schedule_dissociated'
     routing_key_fmt = 'config.outcalls.schedules.deleted'
 
-    def __init__(self, outcall_id: int, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        outcall_id: int,
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'outcall_id': outcall_id,
             'schedule_id': schedule_id,

--- a/xivo_bus/resources/outcall_schedule/event.py
+++ b/xivo_bus/resources/outcall_schedule/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class OutcallScheduleAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class OutcallScheduleAssociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'outcall_id': outcall_id,
@@ -33,7 +34,7 @@ class OutcallScheduleDissociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'outcall_id': outcall_id,

--- a/xivo_bus/resources/outcall_schedule/event.py
+++ b/xivo_bus/resources/outcall_schedule/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class OutcallScheduleAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class OutcallScheduleAssociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'outcall_id': outcall_id,
@@ -34,7 +32,7 @@ class OutcallScheduleDissociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'outcall_id': outcall_id,

--- a/xivo_bus/resources/outcall_trunk/event.py
+++ b/xivo_bus/resources/outcall_trunk/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class OutcallTrunksAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class OutcallTrunksAssociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         trunk_ids: list[int],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'outcall_id': outcall_id,

--- a/xivo_bus/resources/outcall_trunk/event.py
+++ b/xivo_bus/resources/outcall_trunk/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class OutcallTrunksAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class OutcallTrunksAssociatedEvent(TenantEvent):
         self,
         outcall_id: int,
         trunk_ids: list[int],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'outcall_id': outcall_id,

--- a/xivo_bus/resources/outcall_trunk/event.py
+++ b/xivo_bus/resources/outcall_trunk/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class OutcallTrunksAssociatedEvent(TenantEvent):
     name = 'outcall_trunks_associated'
     routing_key_fmt = 'config.outcalls.trunks.updated'
 
-    def __init__(self, outcall_id: int, trunk_ids: list[int], tenant_uuid: str):
+    def __init__(
+        self,
+        outcall_id: int,
+        trunk_ids: list[int],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'outcall_id': outcall_id,
             'trunk_ids': trunk_ids,

--- a/xivo_bus/resources/paging/event.py
+++ b/xivo_bus/resources/paging/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class PagingCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class PagingCreatedEvent(TenantEvent):
     name = 'paging_created'
     routing_key_fmt = 'config.pagings.created'
 
-    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, paging_id: int, tenant_uuid: UUIDStr):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class PagingDeletedEvent(TenantEvent):
     name = 'paging_deleted'
     routing_key_fmt = 'config.pagings.deleted'
 
-    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, paging_id: int, tenant_uuid: UUIDStr):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class PagingEditedEvent(TenantEvent):
     name = 'paging_edited'
     routing_key_fmt = 'config.pagings.edited'
 
-    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, paging_id: int, tenant_uuid: UUIDStr):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/paging/event.py
+++ b/xivo_bus/resources/paging/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class PagingCreatedEvent(TenantEvent):
@@ -11,7 +12,7 @@ class PagingCreatedEvent(TenantEvent):
     name = 'paging_created'
     routing_key_fmt = 'config.pagings.created'
 
-    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)
 
@@ -21,7 +22,7 @@ class PagingDeletedEvent(TenantEvent):
     name = 'paging_deleted'
     routing_key_fmt = 'config.pagings.deleted'
 
-    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)
 
@@ -31,6 +32,6 @@ class PagingEditedEvent(TenantEvent):
     name = 'paging_edited'
     routing_key_fmt = 'config.pagings.edited'
 
-    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/paging/event.py
+++ b/xivo_bus/resources/paging/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,7 @@ class PagingCreatedEvent(TenantEvent):
     name = 'paging_created'
     routing_key_fmt = 'config.pagings.created'
 
-    def __init__(self, paging_id: int, tenant_uuid: str):
+    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +21,7 @@ class PagingDeletedEvent(TenantEvent):
     name = 'paging_deleted'
     routing_key_fmt = 'config.pagings.deleted'
 
-    def __init__(self, paging_id: int, tenant_uuid: str):
+    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +31,6 @@ class PagingEditedEvent(TenantEvent):
     name = 'paging_edited'
     routing_key_fmt = 'config.pagings.edited'
 
-    def __init__(self, paging_id: int, tenant_uuid: str):
+    def __init__(self, paging_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': paging_id}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/paging_user/event.py
+++ b/xivo_bus/resources/paging_user/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class PagingCallerUsersAssociatedEvent(TenantEvent):
     name = 'paging_caller_users_associated'
     routing_key_fmt = 'config.pagings.callers.users.updated'
 
-    def __init__(self, paging_id: int, users: list[str], tenant_uuid: str):
+    def __init__(
+        self,
+        paging_id: int,
+        users: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'paging_id': paging_id,
             'user_uuids': users,
@@ -22,7 +29,12 @@ class PagingMemberUsersAssociatedEvent(TenantEvent):
     name = 'paging_member_users_associated'
     routing_key_fmt = 'config.pagings.members.users.updated'
 
-    def __init__(self, paging_id: int, users: list[str], tenant_uuid: str):
+    def __init__(
+        self,
+        paging_id: int,
+        users: list[str],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'paging_id': paging_id,
             'user_uuids': users,

--- a/xivo_bus/resources/paging_user/event.py
+++ b/xivo_bus/resources/paging_user/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class PagingCallerUsersAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class PagingCallerUsersAssociatedEvent(TenantEvent):
         self,
         paging_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'paging_id': paging_id,
@@ -33,7 +34,7 @@ class PagingMemberUsersAssociatedEvent(TenantEvent):
         self,
         paging_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'paging_id': paging_id,

--- a/xivo_bus/resources/paging_user/event.py
+++ b/xivo_bus/resources/paging_user/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class PagingCallerUsersAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class PagingCallerUsersAssociatedEvent(TenantEvent):
         self,
         paging_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'paging_id': paging_id,
@@ -34,7 +32,7 @@ class PagingMemberUsersAssociatedEvent(TenantEvent):
         self,
         paging_id: int,
         users: list[str],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'paging_id': paging_id,

--- a/xivo_bus/resources/parking_lot/event.py
+++ b/xivo_bus/resources/parking_lot/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class ParkingLotCreatedEvent(TenantEvent):
@@ -11,9 +12,7 @@ class ParkingLotCreatedEvent(TenantEvent):
     name = 'parking_lot_created'
     routing_key_fmt = 'config.parkinglots.created'
 
-    def __init__(
-        self, parking_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, parking_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)
 
@@ -23,9 +22,7 @@ class ParkingLotDeletedEvent(TenantEvent):
     name = 'parking_lot_deleted'
     routing_key_fmt = 'config.parkinglots.deleted'
 
-    def __init__(
-        self, parking_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, parking_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)
 
@@ -35,8 +32,6 @@ class ParkingLotEditedEvent(TenantEvent):
     name = 'parking_lot_edited'
     routing_key_fmt = 'config.parkinglots.edited'
 
-    def __init__(
-        self, parking_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, parking_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/parking_lot/event.py
+++ b/xivo_bus/resources/parking_lot/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class ParkingLotCreatedEvent(TenantEvent):
     name = 'parking_lot_created'
     routing_key_fmt = 'config.parkinglots.created'
 
-    def __init__(self, parking_id: int, tenant_uuid: str):
+    def __init__(
+        self, parking_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +23,9 @@ class ParkingLotDeletedEvent(TenantEvent):
     name = 'parking_lot_deleted'
     routing_key_fmt = 'config.parkinglots.deleted'
 
-    def __init__(self, parking_id: int, tenant_uuid: str):
+    def __init__(
+        self, parking_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +35,8 @@ class ParkingLotEditedEvent(TenantEvent):
     name = 'parking_lot_edited'
     routing_key_fmt = 'config.parkinglots.edited'
 
-    def __init__(self, parking_id: int, tenant_uuid: str):
+    def __init__(
+        self, parking_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/parking_lot/event.py
+++ b/xivo_bus/resources/parking_lot/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ParkingLotCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class ParkingLotCreatedEvent(TenantEvent):
     name = 'parking_lot_created'
     routing_key_fmt = 'config.parkinglots.created'
 
-    def __init__(self, parking_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, parking_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class ParkingLotDeletedEvent(TenantEvent):
     name = 'parking_lot_deleted'
     routing_key_fmt = 'config.parkinglots.deleted'
 
-    def __init__(self, parking_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, parking_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class ParkingLotEditedEvent(TenantEvent):
     name = 'parking_lot_edited'
     routing_key_fmt = 'config.parkinglots.edited'
 
-    def __init__(self, parking_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, parking_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(parking_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/parking_lot_extension/event.py
+++ b/xivo_bus/resources/parking_lot_extension/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class ParkingLotExtensionAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class ParkingLotExtensionAssociatedEvent(TenantEvent):
         self,
         parking_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'parking_lot_id': parking_id,
@@ -33,7 +34,7 @@ class ParkingLotExtensionDissociatedEvent(TenantEvent):
         self,
         parking_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'parking_lot_id': parking_id,

--- a/xivo_bus/resources/parking_lot_extension/event.py
+++ b/xivo_bus/resources/parking_lot_extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ParkingLotExtensionAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class ParkingLotExtensionAssociatedEvent(TenantEvent):
         self,
         parking_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'parking_lot_id': parking_id,
@@ -34,7 +32,7 @@ class ParkingLotExtensionDissociatedEvent(TenantEvent):
         self,
         parking_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'parking_lot_id': parking_id,

--- a/xivo_bus/resources/parking_lot_extension/event.py
+++ b/xivo_bus/resources/parking_lot_extension/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class ParkingLotExtensionAssociatedEvent(TenantEvent):
     name = 'parking_lot_extension_associated'
     routing_key_fmt = 'config.parkinglots.extensions.updated'
 
-    def __init__(self, parking_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        parking_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'parking_lot_id': parking_id,
             'extension_id': extension_id,
@@ -22,7 +29,12 @@ class ParkingLotExtensionDissociatedEvent(TenantEvent):
     name = 'parking_lot_extension_dissociated'
     routing_key_fmt = 'config.parkinglots.extensions.deleted'
 
-    def __init__(self, parking_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        parking_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'parking_lot_id': parking_id,
             'extension_id': extension_id,

--- a/xivo_bus/resources/pjsip/types.py
+++ b/xivo_bus/resources/pjsip/types.py
@@ -3,12 +3,12 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class PJSIPTransportDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     name: str
     options: list[str]

--- a/xivo_bus/resources/pjsip/types.py
+++ b/xivo_bus/resources/pjsip/types.py
@@ -1,12 +1,12 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class PJSIPTransportDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     name: str
     options: list[str]

--- a/xivo_bus/resources/pjsip/types.py
+++ b/xivo_bus/resources/pjsip/types.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class PJSIPTransportDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     name: str
     options: list[str]

--- a/xivo_bus/resources/plugins/events.py
+++ b/xivo_bus/resources/plugins/events.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from ..common.event import ServiceEvent
+from ..common.types import Format
 from .types import PluginErrorDict
 
 
@@ -16,7 +17,7 @@ class PluginInstallProgressEvent(ServiceEvent):
 
     def __init__(
         self,
-        plugin_uuid: Annotated[str, {'format': 'uuid'}],
+        plugin_uuid: Annotated[str, Format('uuid')],
         status: str,
         errors: PluginErrorDict | None = None,
     ):
@@ -33,7 +34,7 @@ class PluginUninstallProgressEvent(ServiceEvent):
 
     def __init__(
         self,
-        plugin_uuid: Annotated[str, {'format': 'uuid'}],
+        plugin_uuid: Annotated[str, Format('uuid')],
         status: str,
         errors: PluginErrorDict | None = None,
     ):

--- a/xivo_bus/resources/plugins/events.py
+++ b/xivo_bus/resources/plugins/events.py
@@ -1,7 +1,9 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
+
+from typing import Annotated
 
 from ..common.event import ServiceEvent
 from .types import PluginErrorDict
@@ -13,7 +15,10 @@ class PluginInstallProgressEvent(ServiceEvent):
     routing_key_fmt = 'plugin.install.{uuid}.{status}'
 
     def __init__(
-        self, plugin_uuid: str, status: str, errors: PluginErrorDict | None = None
+        self,
+        plugin_uuid: Annotated[str, {'format': 'uuid'}],
+        status: str,
+        errors: PluginErrorDict | None = None,
     ):
         content = {'uuid': plugin_uuid, 'status': status}
         if errors:
@@ -27,7 +32,10 @@ class PluginUninstallProgressEvent(ServiceEvent):
     routing_key_fmt = 'plugin.uninstall.{uuid}.{status}'
 
     def __init__(
-        self, plugin_uuid: str, status: str, errors: PluginErrorDict | None = None
+        self,
+        plugin_uuid: Annotated[str, {'format': 'uuid'}],
+        status: str,
+        errors: PluginErrorDict | None = None,
     ):
         content = {'uuid': plugin_uuid, 'status': status}
         if errors:

--- a/xivo_bus/resources/plugins/events.py
+++ b/xivo_bus/resources/plugins/events.py
@@ -3,10 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
 from ..common.event import ServiceEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import PluginErrorDict
 
 
@@ -17,7 +15,7 @@ class PluginInstallProgressEvent(ServiceEvent):
 
     def __init__(
         self,
-        plugin_uuid: Annotated[str, Format('uuid')],
+        plugin_uuid: UUIDStr,
         status: str,
         errors: PluginErrorDict | None = None,
     ):
@@ -34,7 +32,7 @@ class PluginUninstallProgressEvent(ServiceEvent):
 
     def __init__(
         self,
-        plugin_uuid: Annotated[str, Format('uuid')],
+        plugin_uuid: UUIDStr,
         status: str,
         errors: PluginErrorDict | None = None,
     ):

--- a/xivo_bus/resources/push_notification/events.py
+++ b/xivo_bus/resources/push_notification/events.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 from .types import PushMobileDict
 
 
@@ -16,8 +17,8 @@ class CallPushNotificationEvent(UserEvent):
     def __init__(
         self,
         push: PushMobileDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(push, tenant_uuid, user_uuid)
 
@@ -31,7 +32,7 @@ class CallCancelPushNotificationEvent(UserEvent):
     def __init__(
         self,
         push: PushMobileDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(push, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/push_notification/events.py
+++ b/xivo_bus/resources/push_notification/events.py
@@ -1,5 +1,7 @@
-# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
+
+from typing import Annotated
 
 from ..common.event import UserEvent
 from .types import PushMobileDict
@@ -11,7 +13,12 @@ class CallPushNotificationEvent(UserEvent):
     routing_key_fmt = 'calls.call.push_notification'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, push: PushMobileDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        push: PushMobileDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(push, tenant_uuid, user_uuid)
 
 
@@ -21,5 +28,10 @@ class CallCancelPushNotificationEvent(UserEvent):
     routing_key_fmt = 'calls.call.cancel_push_notification'
     required_acl_fmt = 'events.calls.{user_uuid}'
 
-    def __init__(self, push: PushMobileDict, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        push: PushMobileDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         super().__init__(push, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/push_notification/events.py
+++ b/xivo_bus/resources/push_notification/events.py
@@ -1,10 +1,8 @@
 # Copyright 2022-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0+
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import PushMobileDict
 
 
@@ -17,8 +15,8 @@ class CallPushNotificationEvent(UserEvent):
     def __init__(
         self,
         push: PushMobileDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(push, tenant_uuid, user_uuid)
 
@@ -32,7 +30,7 @@ class CallCancelPushNotificationEvent(UserEvent):
     def __init__(
         self,
         push: PushMobileDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         super().__init__(push, tenant_uuid, user_uuid)

--- a/xivo_bus/resources/queue/event.py
+++ b/xivo_bus/resources/queue/event.py
@@ -1,5 +1,7 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,7 @@ class QueueCreatedEvent(TenantEvent):
     name = 'queue_created'
     routing_key_fmt = 'config.queues.created'
 
-    def __init__(self, queue_id: int, tenant_uuid: str):
+    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +21,7 @@ class QueueDeletedEvent(TenantEvent):
     name = 'queue_deleted'
     routing_key_fmt = 'config.queues.deleted'
 
-    def __init__(self, queue_id: int, tenant_uuid: str):
+    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -29,7 +31,7 @@ class QueueEditedEvent(TenantEvent):
     name = 'queue_edited'
     routing_key_fmt = 'config.queues.edited'
 
-    def __init__(self, queue_id: int, tenant_uuid: str):
+    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -39,6 +41,6 @@ class QueueFallbackEditedEvent(TenantEvent):
     name = 'queue_fallback_edited'
     routing_key_fmt = 'config.queues.fallbacks.edited'
 
-    def __init__(self, queue_id: int, tenant_uuid: str):
+    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/queue/event.py
+++ b/xivo_bus/resources/queue/event.py
@@ -1,10 +1,8 @@
 # Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class QueueCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class QueueCreatedEvent(TenantEvent):
     name = 'queue_created'
     routing_key_fmt = 'config.queues.created'
 
-    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, queue_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class QueueDeletedEvent(TenantEvent):
     name = 'queue_deleted'
     routing_key_fmt = 'config.queues.deleted'
 
-    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, queue_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -32,7 +30,7 @@ class QueueEditedEvent(TenantEvent):
     name = 'queue_edited'
     routing_key_fmt = 'config.queues.edited'
 
-    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, queue_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -42,6 +40,6 @@ class QueueFallbackEditedEvent(TenantEvent):
     name = 'queue_fallback_edited'
     routing_key_fmt = 'config.queues.fallbacks.edited'
 
-    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, queue_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/queue/event.py
+++ b/xivo_bus/resources/queue/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class QueueCreatedEvent(TenantEvent):
@@ -11,7 +12,7 @@ class QueueCreatedEvent(TenantEvent):
     name = 'queue_created'
     routing_key_fmt = 'config.queues.created'
 
-    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -21,7 +22,7 @@ class QueueDeletedEvent(TenantEvent):
     name = 'queue_deleted'
     routing_key_fmt = 'config.queues.deleted'
 
-    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -31,7 +32,7 @@ class QueueEditedEvent(TenantEvent):
     name = 'queue_edited'
     routing_key_fmt = 'config.queues.edited'
 
-    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)
 
@@ -41,6 +42,6 @@ class QueueFallbackEditedEvent(TenantEvent):
     name = 'queue_fallback_edited'
     routing_key_fmt = 'config.queues.fallbacks.edited'
 
-    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, queue_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(queue_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/queue_extension/event.py
+++ b/xivo_bus/resources/queue_extension/event.py
@@ -3,7 +3,8 @@
 
 from typing import Annotated
 
-from xivo_bus.resources.common.event import TenantEvent
+from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class QueueExtensionAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class QueueExtensionAssociatedEvent(TenantEvent):
         self,
         queue_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'queue_id': queue_id,
@@ -33,7 +34,7 @@ class QueueExtensionDissociatedEvent(TenantEvent):
         self,
         queue_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'queue_id': queue_id,

--- a/xivo_bus/resources/queue_extension/event.py
+++ b/xivo_bus/resources/queue_extension/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from xivo_bus.resources.common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class QueueExtensionAssociatedEvent(TenantEvent):
     name = 'queue_extension_associated'
     routing_key_fmt = 'config.queues.extensions.updated'
 
-    def __init__(self, queue_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        queue_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'queue_id': queue_id,
             'extension_id': extension_id,
@@ -22,7 +29,12 @@ class QueueExtensionDissociatedEvent(TenantEvent):
     name = 'queue_extension_dissociated'
     routing_key_fmt = 'config.queues.extensions.deleted'
 
-    def __init__(self, queue_id: int, extension_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        queue_id: int,
+        extension_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'queue_id': queue_id,
             'extension_id': extension_id,

--- a/xivo_bus/resources/queue_extension/event.py
+++ b/xivo_bus/resources/queue_extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class QueueExtensionAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class QueueExtensionAssociatedEvent(TenantEvent):
         self,
         queue_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'queue_id': queue_id,
@@ -34,7 +32,7 @@ class QueueExtensionDissociatedEvent(TenantEvent):
         self,
         queue_id: int,
         extension_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'queue_id': queue_id,

--- a/xivo_bus/resources/queue_member/event.py
+++ b/xivo_bus/resources/queue_member/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 
 
 class QueueMemberAgentAssociatedEvent(TenantEvent):
@@ -16,7 +17,7 @@ class QueueMemberAgentAssociatedEvent(TenantEvent):
         queue_id: int,
         agent_id: int,
         penalty: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'queue_id': queue_id,
@@ -35,7 +36,7 @@ class QueueMemberAgentDissociatedEvent(TenantEvent):
         self,
         queue_id: int,
         agent_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'queue_id': queue_id,
@@ -52,8 +53,8 @@ class QueueMemberUserAssociatedEvent(UserEvent):
     def __init__(
         self,
         queue_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'queue_id': queue_id,
@@ -70,8 +71,8 @@ class QueueMemberUserDissociatedEvent(UserEvent):
     def __init__(
         self,
         queue_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'queue_id': queue_id,

--- a/xivo_bus/resources/queue_member/event.py
+++ b/xivo_bus/resources/queue_member/event.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
 
@@ -9,7 +11,13 @@ class QueueMemberAgentAssociatedEvent(TenantEvent):
     name = 'queue_member_agent_associated'
     routing_key_fmt = 'config.queues.agents.updated'
 
-    def __init__(self, queue_id: int, agent_id: int, penalty: int, tenant_uuid: str):
+    def __init__(
+        self,
+        queue_id: int,
+        agent_id: int,
+        penalty: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'queue_id': queue_id,
             'agent_id': agent_id,
@@ -23,7 +31,12 @@ class QueueMemberAgentDissociatedEvent(TenantEvent):
     name = 'queue_member_agent_dissociated'
     routing_key_fmt = 'config.queues.agents.deleted'
 
-    def __init__(self, queue_id: int, agent_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        queue_id: int,
+        agent_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'queue_id': queue_id,
             'agent_id': agent_id,
@@ -36,7 +49,12 @@ class QueueMemberUserAssociatedEvent(UserEvent):
     name = 'queue_member_user_associated'
     routing_key_fmt = 'config.queues.users.updated'
 
-    def __init__(self, queue_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        queue_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'queue_id': queue_id,
             'user_uuid': str(user_uuid),
@@ -49,7 +67,12 @@ class QueueMemberUserDissociatedEvent(UserEvent):
     name = 'queue_member_user_dissociated'
     routing_key_fmt = 'config.queues.users.deleted'
 
-    def __init__(self, queue_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        queue_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'queue_id': queue_id,
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/queue_member/event.py
+++ b/xivo_bus/resources/queue_member/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class QueueMemberAgentAssociatedEvent(TenantEvent):
@@ -17,7 +15,7 @@ class QueueMemberAgentAssociatedEvent(TenantEvent):
         queue_id: int,
         agent_id: int,
         penalty: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'queue_id': queue_id,
@@ -36,7 +34,7 @@ class QueueMemberAgentDissociatedEvent(TenantEvent):
         self,
         queue_id: int,
         agent_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'queue_id': queue_id,
@@ -53,8 +51,8 @@ class QueueMemberUserAssociatedEvent(UserEvent):
     def __init__(
         self,
         queue_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'queue_id': queue_id,
@@ -71,8 +69,8 @@ class QueueMemberUserDissociatedEvent(UserEvent):
     def __init__(
         self,
         queue_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'queue_id': queue_id,

--- a/xivo_bus/resources/queue_schedule/event.py
+++ b/xivo_bus/resources/queue_schedule/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class QueueScheduleAssociatedEvent(TenantEvent):
     name = 'queue_schedule_associated'
     routing_key_fmt = 'config.queues.schedules.updated'
 
-    def __init__(self, queue_id: int, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        queue_id: int,
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'queue_id': queue_id,
             'schedule_id': schedule_id,
@@ -22,7 +29,12 @@ class QueueScheduleDissociatedEvent(TenantEvent):
     name = 'queue_schedule_dissociated'
     routing_key_fmt = 'config.queues.schedules.deleted'
 
-    def __init__(self, queue_id: int, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        queue_id: int,
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'queue_id': queue_id,
             'schedule_id': schedule_id,

--- a/xivo_bus/resources/queue_schedule/event.py
+++ b/xivo_bus/resources/queue_schedule/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class QueueScheduleAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class QueueScheduleAssociatedEvent(TenantEvent):
         self,
         queue_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'queue_id': queue_id,
@@ -33,7 +34,7 @@ class QueueScheduleDissociatedEvent(TenantEvent):
         self,
         queue_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'queue_id': queue_id,

--- a/xivo_bus/resources/queue_schedule/event.py
+++ b/xivo_bus/resources/queue_schedule/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class QueueScheduleAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class QueueScheduleAssociatedEvent(TenantEvent):
         self,
         queue_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'queue_id': queue_id,
@@ -34,7 +32,7 @@ class QueueScheduleDissociatedEvent(TenantEvent):
         self,
         queue_id: int,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'queue_id': queue_id,

--- a/xivo_bus/resources/schedule/event.py
+++ b/xivo_bus/resources/schedule/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class ScheduleCreatedEvent(TenantEvent):
     name = 'schedule_created'
     routing_key_fmt = 'config.schedules.created'
 
-    def __init__(self, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self, schedule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +23,9 @@ class ScheduleDeletedEvent(TenantEvent):
     name = 'schedule_deleted'
     routing_key_fmt = 'config.schedules.deleted'
 
-    def __init__(self, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self, schedule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +35,8 @@ class ScheduleEditedEvent(TenantEvent):
     name = 'schedule_edited'
     routing_key_fmt = 'config.schedules.edited'
 
-    def __init__(self, schedule_id: int, tenant_uuid: str):
+    def __init__(
+        self, schedule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/schedule/event.py
+++ b/xivo_bus/resources/schedule/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class ScheduleCreatedEvent(TenantEvent):
@@ -11,9 +12,7 @@ class ScheduleCreatedEvent(TenantEvent):
     name = 'schedule_created'
     routing_key_fmt = 'config.schedules.created'
 
-    def __init__(
-        self, schedule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, schedule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -23,9 +22,7 @@ class ScheduleDeletedEvent(TenantEvent):
     name = 'schedule_deleted'
     routing_key_fmt = 'config.schedules.deleted'
 
-    def __init__(
-        self, schedule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, schedule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -35,8 +32,6 @@ class ScheduleEditedEvent(TenantEvent):
     name = 'schedule_edited'
     routing_key_fmt = 'config.schedules.edited'
 
-    def __init__(
-        self, schedule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, schedule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/schedule/event.py
+++ b/xivo_bus/resources/schedule/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ScheduleCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class ScheduleCreatedEvent(TenantEvent):
     name = 'schedule_created'
     routing_key_fmt = 'config.schedules.created'
 
-    def __init__(self, schedule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, schedule_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class ScheduleDeletedEvent(TenantEvent):
     name = 'schedule_deleted'
     routing_key_fmt = 'config.schedules.deleted'
 
-    def __init__(self, schedule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, schedule_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class ScheduleEditedEvent(TenantEvent):
     name = 'schedule_edited'
     routing_key_fmt = 'config.schedules.edited'
 
-    def __init__(self, schedule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, schedule_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(schedule_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/skill/event.py
+++ b/xivo_bus/resources/skill/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,7 @@ class SkillCreatedEvent(TenantEvent):
     name = 'skill_created'
     routing_key_fmt = 'config.agents.skills.created'
 
-    def __init__(self, skill_id: int, tenant_uuid: str):
+    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +21,7 @@ class SkillDeletedEvent(TenantEvent):
     name = 'skill_deleted'
     routing_key_fmt = 'config.agents.skills.deleted'
 
-    def __init__(self, skill_id: int, tenant_uuid: str):
+    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +31,6 @@ class SkillEditedEvent(TenantEvent):
     name = 'skill_edited'
     routing_key_fmt = 'config.agents.skills.edited'
 
-    def __init__(self, skill_id: int, tenant_uuid: str):
+    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/skill/event.py
+++ b/xivo_bus/resources/skill/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class SkillCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class SkillCreatedEvent(TenantEvent):
     name = 'skill_created'
     routing_key_fmt = 'config.agents.skills.created'
 
-    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, skill_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class SkillDeletedEvent(TenantEvent):
     name = 'skill_deleted'
     routing_key_fmt = 'config.agents.skills.deleted'
 
-    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, skill_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class SkillEditedEvent(TenantEvent):
     name = 'skill_edited'
     routing_key_fmt = 'config.agents.skills.edited'
 
-    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, skill_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/skill/event.py
+++ b/xivo_bus/resources/skill/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class SkillCreatedEvent(TenantEvent):
@@ -11,7 +12,7 @@ class SkillCreatedEvent(TenantEvent):
     name = 'skill_created'
     routing_key_fmt = 'config.agents.skills.created'
 
-    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)
 
@@ -21,7 +22,7 @@ class SkillDeletedEvent(TenantEvent):
     name = 'skill_deleted'
     routing_key_fmt = 'config.agents.skills.deleted'
 
-    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)
 
@@ -31,6 +32,6 @@ class SkillEditedEvent(TenantEvent):
     name = 'skill_edited'
     routing_key_fmt = 'config.agents.skills.edited'
 
-    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, skill_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(skill_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/skill_rule/event.py
+++ b/xivo_bus/resources/skill_rule/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class SkillRuleCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class SkillRuleCreatedEvent(TenantEvent):
     name = 'skill_rule_created'
     routing_key_fmt = 'config.queues.skillrules.created'
 
-    def __init__(self, skill_rule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, skill_rule_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class SkillRuleDeletedEvent(TenantEvent):
     name = 'skill_rule_deleted'
     routing_key_fmt = 'config.queues.skillrules.deleted'
 
-    def __init__(self, skill_rule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, skill_rule_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -32,6 +30,6 @@ class SkillRuleEditedEvent(TenantEvent):
     name = 'skill_rule_edited'
     routing_key_fmt = 'config.queues.skillrules.edited'
 
-    def __init__(self, skill_rule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, skill_rule_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/skill_rule/event.py
+++ b/xivo_bus/resources/skill_rule/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class SkillRuleCreatedEvent(TenantEvent):
@@ -11,9 +12,7 @@ class SkillRuleCreatedEvent(TenantEvent):
     name = 'skill_rule_created'
     routing_key_fmt = 'config.queues.skillrules.created'
 
-    def __init__(
-        self, skill_rule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, skill_rule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -23,9 +22,7 @@ class SkillRuleDeletedEvent(TenantEvent):
     name = 'skill_rule_deleted'
     routing_key_fmt = 'config.queues.skillrules.deleted'
 
-    def __init__(
-        self, skill_rule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, skill_rule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -35,8 +32,6 @@ class SkillRuleEditedEvent(TenantEvent):
     name = 'skill_rule_edited'
     routing_key_fmt = 'config.queues.skillrules.edited'
 
-    def __init__(
-        self, skill_rule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, skill_rule_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/skill_rule/event.py
+++ b/xivo_bus/resources/skill_rule/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class SkillRuleCreatedEvent(TenantEvent):
     name = 'skill_rule_created'
     routing_key_fmt = 'config.queues.skillrules.created'
 
-    def __init__(self, skill_rule_id: int, tenant_uuid: str):
+    def __init__(
+        self, skill_rule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +23,9 @@ class SkillRuleDeletedEvent(TenantEvent):
     name = 'skill_rule_deleted'
     routing_key_fmt = 'config.queues.skillrules.deleted'
 
-    def __init__(self, skill_rule_id: int, tenant_uuid: str):
+    def __init__(
+        self, skill_rule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)
 
@@ -29,6 +35,8 @@ class SkillRuleEditedEvent(TenantEvent):
     name = 'skill_rule_edited'
     routing_key_fmt = 'config.queues.skillrules.edited'
 
-    def __init__(self, skill_rule_id: int, tenant_uuid: str):
+    def __init__(
+        self, skill_rule_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(skill_rule_id)}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/sound/event.py
+++ b/xivo_bus/resources/sound/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,9 @@ class SoundCreatedEvent(TenantEvent):
     name = 'sound_created'
     routing_key_fmt = 'config.sounds.created'
 
-    def __init__(self, sound_name: str, tenant_uuid: str):
+    def __init__(
+        self, sound_name: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'name': sound_name}
         super().__init__(content, tenant_uuid)
 
@@ -19,6 +23,8 @@ class SoundDeletedEvent(TenantEvent):
     name = 'sound_deleted'
     routing_key_fmt = 'config.sounds.deleted'
 
-    def __init__(self, sound_name: str, tenant_uuid: str):
+    def __init__(
+        self, sound_name: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'name': sound_name}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/sound/event.py
+++ b/xivo_bus/resources/sound/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class SoundCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class SoundCreatedEvent(TenantEvent):
     name = 'sound_created'
     routing_key_fmt = 'config.sounds.created'
 
-    def __init__(self, sound_name: str, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, sound_name: str, tenant_uuid: UUIDStr):
         content = {'name': sound_name}
         super().__init__(content, tenant_uuid)
 
@@ -22,6 +20,6 @@ class SoundDeletedEvent(TenantEvent):
     name = 'sound_deleted'
     routing_key_fmt = 'config.sounds.deleted'
 
-    def __init__(self, sound_name: str, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, sound_name: str, tenant_uuid: UUIDStr):
         content = {'name': sound_name}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/sound/event.py
+++ b/xivo_bus/resources/sound/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class SoundCreatedEvent(TenantEvent):
@@ -11,9 +12,7 @@ class SoundCreatedEvent(TenantEvent):
     name = 'sound_created'
     routing_key_fmt = 'config.sounds.created'
 
-    def __init__(
-        self, sound_name: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, sound_name: str, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'name': sound_name}
         super().__init__(content, tenant_uuid)
 
@@ -23,8 +22,6 @@ class SoundDeletedEvent(TenantEvent):
     name = 'sound_deleted'
     routing_key_fmt = 'config.sounds.deleted'
 
-    def __init__(
-        self, sound_name: str, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, sound_name: str, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'name': sound_name}
         super().__init__(content, tenant_uuid)

--- a/xivo_bus/resources/switchboard/event.py
+++ b/xivo_bus/resources/switchboard/event.py
@@ -1,10 +1,10 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from typing import Annotated, Any
 
 from ..common.acl import escape as escape_acl
 from ..common.event import MultiUserEvent, TenantEvent
@@ -18,7 +18,12 @@ from .types import (
 
 
 class _SwitchboardMixin:
-    def __init__(self, content: Mapping, switchboard_uuid: str, *args: Any):
+    def __init__(
+        self,
+        content: Mapping,
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        *args: Any,
+    ):
         super().__init__(content, *args)  # type: ignore[call-arg]
         if switchboard_uuid is None:
             raise ValueError('switchboard_uuid must have a value')
@@ -32,7 +37,10 @@ class SwitchboardCreatedEvent(_SwitchboardMixin, TenantEvent):
     required_acl_fmt = 'switchboards.{switchboard_uuid}.created'
 
     def __init__(
-        self, switchboard: SwitchboardDict, switchboard_uuid: str, tenant_uuid: str
+        self,
+        switchboard: SwitchboardDict,
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -44,7 +52,10 @@ class SwitchboardDeletedEvent(_SwitchboardMixin, TenantEvent):
     required_acl_fmt = 'switchboards.{switchboard_uuid}.deleted'
 
     def __init__(
-        self, switchboard: SwitchboardDict, switchboard_uuid: str, tenant_uuid: str
+        self,
+        switchboard: SwitchboardDict,
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -56,7 +67,10 @@ class SwitchboardEditedEvent(_SwitchboardMixin, TenantEvent):
     required_acl_fmt = 'switchboards.{switchboard_uuid}.edited'
 
     def __init__(
-        self, switchboard: SwitchboardDict, switchboard_uuid: str, tenant_uuid: str
+        self,
+        switchboard: SwitchboardDict,
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -68,7 +82,10 @@ class SwitchboardFallbackEditedEvent(_SwitchboardMixin, TenantEvent):
     required_acl_fmt = 'switchboards.fallbacks.edited'
 
     def __init__(
-        self, fallback: SwitchboardFallbackDict, switchboard_uuid: str, tenant_uuid: str
+        self,
+        fallback: SwitchboardFallbackDict,
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         super().__init__(fallback, switchboard_uuid, tenant_uuid)
 
@@ -79,7 +96,12 @@ class SwitchboardMemberUserAssociatedEvent(_SwitchboardMixin, MultiUserEvent):
     routing_key_fmt = 'config.switchboards.{switchboard_uuid}.members.users.updated'
     required_acl_fmt = 'switchboards.{switchboard_uuid}.members.users.updated'
 
-    def __init__(self, switchboard_uuid: str, tenant_uuid: str, user_uuids: list[str]):
+    def __init__(
+        self,
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuids: list[str],
+    ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
             'users': [{'uuid': str(uuid)} for uuid in user_uuids],
@@ -93,7 +115,10 @@ class SwitchboardQueuedCallsUpdatedEvent(_SwitchboardMixin, TenantEvent):
     routing_key_fmt = 'switchboards.{switchboard_uuid}.calls.queued.updated'
 
     def __init__(
-        self, items: list[QueuedCallDict], switchboard_uuid: str, tenant_uuid: str
+        self,
+        items: list[QueuedCallDict],
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -114,8 +139,8 @@ class SwitchboardQueuedCallAnsweredEvent(_SwitchboardMixin, TenantEvent):
         self,
         operator_call_id: str,
         queued_call_id: str,
-        switchboard_uuid: str,
-        tenant_uuid: str,
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -137,7 +162,10 @@ class SwitchboardHeldCallsUpdatedEvent(_SwitchboardMixin, TenantEvent):
     routing_key_fmt = 'switchboards.{switchboard_uuid}.calls.held.updated'
 
     def __init__(
-        self, items: list[HeldCallDict], switchboard_uuid: str, tenant_uuid: str
+        self,
+        items: list[HeldCallDict],
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -158,8 +186,8 @@ class SwitchboardHeldCallAnsweredEvent(_SwitchboardMixin, TenantEvent):
         self,
         operator_call_id: str,
         held_call_id: str,
-        switchboard_uuid: str,
-        tenant_uuid: str,
+        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),

--- a/xivo_bus/resources/switchboard/event.py
+++ b/xivo_bus/resources/switchboard/event.py
@@ -4,12 +4,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Annotated, Any
+from typing import Any
 
 from ..common.acl import escape as escape_acl
 from ..common.event import MultiUserEvent, TenantEvent
 from ..common.routing_key import escape as escape_key
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import (
     HeldCallDict,
     QueuedCallDict,
@@ -22,7 +22,7 @@ class _SwitchboardMixin:
     def __init__(
         self,
         content: Mapping,
-        switchboard_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
         *args: Any,
     ):
         super().__init__(content, *args)  # type: ignore[call-arg]
@@ -40,8 +40,8 @@ class SwitchboardCreatedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         switchboard: SwitchboardDict,
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -55,8 +55,8 @@ class SwitchboardDeletedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         switchboard: SwitchboardDict,
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -70,8 +70,8 @@ class SwitchboardEditedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         switchboard: SwitchboardDict,
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -85,8 +85,8 @@ class SwitchboardFallbackEditedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         fallback: SwitchboardFallbackDict,
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         super().__init__(fallback, switchboard_uuid, tenant_uuid)
 
@@ -99,8 +99,8 @@ class SwitchboardMemberUserAssociatedEvent(_SwitchboardMixin, MultiUserEvent):
 
     def __init__(
         self,
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
         user_uuids: list[str],
     ):
         content = {
@@ -118,8 +118,8 @@ class SwitchboardQueuedCallsUpdatedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         items: list[QueuedCallDict],
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -140,8 +140,8 @@ class SwitchboardQueuedCallAnsweredEvent(_SwitchboardMixin, TenantEvent):
         self,
         operator_call_id: str,
         queued_call_id: str,
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -165,8 +165,8 @@ class SwitchboardHeldCallsUpdatedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         items: list[HeldCallDict],
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -187,8 +187,8 @@ class SwitchboardHeldCallAnsweredEvent(_SwitchboardMixin, TenantEvent):
         self,
         operator_call_id: str,
         held_call_id: str,
-        switchboard_uuid: Annotated[str, Format('uuid')],
-        tenant_uuid: Annotated[str, Format('uuid')],
+        switchboard_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),

--- a/xivo_bus/resources/switchboard/event.py
+++ b/xivo_bus/resources/switchboard/event.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 from ..common.acl import escape as escape_acl
 from ..common.event import MultiUserEvent, TenantEvent
 from ..common.routing_key import escape as escape_key
+from ..common.types import Format
 from .types import (
     HeldCallDict,
     QueuedCallDict,
@@ -21,7 +22,7 @@ class _SwitchboardMixin:
     def __init__(
         self,
         content: Mapping,
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
         *args: Any,
     ):
         super().__init__(content, *args)  # type: ignore[call-arg]
@@ -39,8 +40,8 @@ class SwitchboardCreatedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         switchboard: SwitchboardDict,
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -54,8 +55,8 @@ class SwitchboardDeletedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         switchboard: SwitchboardDict,
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -69,8 +70,8 @@ class SwitchboardEditedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         switchboard: SwitchboardDict,
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(switchboard, switchboard_uuid, tenant_uuid)
 
@@ -84,8 +85,8 @@ class SwitchboardFallbackEditedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         fallback: SwitchboardFallbackDict,
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         super().__init__(fallback, switchboard_uuid, tenant_uuid)
 
@@ -98,8 +99,8 @@ class SwitchboardMemberUserAssociatedEvent(_SwitchboardMixin, MultiUserEvent):
 
     def __init__(
         self,
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
         user_uuids: list[str],
     ):
         content = {
@@ -117,8 +118,8 @@ class SwitchboardQueuedCallsUpdatedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         items: list[QueuedCallDict],
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -139,8 +140,8 @@ class SwitchboardQueuedCallAnsweredEvent(_SwitchboardMixin, TenantEvent):
         self,
         operator_call_id: str,
         queued_call_id: str,
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -164,8 +165,8 @@ class SwitchboardHeldCallsUpdatedEvent(_SwitchboardMixin, TenantEvent):
     def __init__(
         self,
         items: list[HeldCallDict],
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),
@@ -186,8 +187,8 @@ class SwitchboardHeldCallAnsweredEvent(_SwitchboardMixin, TenantEvent):
         self,
         operator_call_id: str,
         held_call_id: str,
-        switchboard_uuid: Annotated[str, {'format': 'uuid'}],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        switchboard_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'switchboard_uuid': str(switchboard_uuid),

--- a/xivo_bus/resources/switchboard/types.py
+++ b/xivo_bus/resources/switchboard/types.py
@@ -45,7 +45,7 @@ class SwitchboardDict(TypedDict, total=False):
 
 
 class SwitchboardFallbackDict(TypedDict, total=False):
-    noanswer_destination: Any | None
+    noanswer_destination: Any
 
 
 class UserDict(TypedDict, total=False):

--- a/xivo_bus/resources/switchboard/types.py
+++ b/xivo_bus/resources/switchboard/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, Any, TypedDict
 
+from ..common.types import Format
+
 
 class ExtensionDict(TypedDict, total=False):
     id: int
@@ -30,8 +32,8 @@ class QueuedCallDict(TypedDict, total=False):
 
 
 class SwitchboardDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     name: str
     timeout: int
     queue_music_on_hold: str
@@ -47,6 +49,6 @@ class SwitchboardFallbackDict(TypedDict, total=False):
 
 
 class UserDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
     firstname: str
     lastname: str

--- a/xivo_bus/resources/switchboard/types.py
+++ b/xivo_bus/resources/switchboard/types.py
@@ -1,9 +1,9 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import Any, TypedDict
+from typing import Annotated, Any, TypedDict
 
 
 class ExtensionDict(TypedDict, total=False):
@@ -30,8 +30,8 @@ class QueuedCallDict(TypedDict, total=False):
 
 
 class SwitchboardDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     name: str
     timeout: int
     queue_music_on_hold: str
@@ -47,6 +47,6 @@ class SwitchboardFallbackDict(TypedDict, total=False):
 
 
 class UserDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
     firstname: str
     lastname: str

--- a/xivo_bus/resources/switchboard/types.py
+++ b/xivo_bus/resources/switchboard/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any, TypedDict
+from typing import Any, TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class ExtensionDict(TypedDict, total=False):
@@ -32,8 +32,8 @@ class QueuedCallDict(TypedDict, total=False):
 
 
 class SwitchboardDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     name: str
     timeout: int
     queue_music_on_hold: str
@@ -49,6 +49,6 @@ class SwitchboardFallbackDict(TypedDict, total=False):
 
 
 class UserDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
     firstname: str
     lastname: str

--- a/xivo_bus/resources/sysconfd/event.py
+++ b/xivo_bus/resources/sysconfd/event.py
@@ -3,10 +3,8 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
 from ..common.event import ServiceEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class RequestHandlersProgressEvent(ServiceEvent):
@@ -16,7 +14,7 @@ class RequestHandlersProgressEvent(ServiceEvent):
 
     def __init__(
         self,
-        request_uuid: Annotated[str, Format('uuid')],
+        request_uuid: UUIDStr,
         request_context: dict | None,
         status: str,
     ):
@@ -35,7 +33,7 @@ class AsteriskReloadProgressEvent(ServiceEvent):
 
     def __init__(
         self,
-        uuid: Annotated[str, Format('uuid')],
+        uuid: UUIDStr,
         status: str,
         command: str,
         request_uuids: list[str],

--- a/xivo_bus/resources/sysconfd/event.py
+++ b/xivo_bus/resources/sysconfd/event.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from ..common.event import ServiceEvent
+from ..common.types import Format
 
 
 class RequestHandlersProgressEvent(ServiceEvent):
@@ -15,7 +16,7 @@ class RequestHandlersProgressEvent(ServiceEvent):
 
     def __init__(
         self,
-        request_uuid: Annotated[str, {'format': 'uuid'}],
+        request_uuid: Annotated[str, Format('uuid')],
         request_context: dict | None,
         status: str,
     ):
@@ -34,7 +35,7 @@ class AsteriskReloadProgressEvent(ServiceEvent):
 
     def __init__(
         self,
-        uuid: Annotated[str, {'format': 'uuid'}],
+        uuid: Annotated[str, Format('uuid')],
         status: str,
         command: str,
         request_uuids: list[str],

--- a/xivo_bus/resources/sysconfd/event.py
+++ b/xivo_bus/resources/sysconfd/event.py
@@ -1,7 +1,9 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
+
+from typing import Annotated
 
 from ..common.event import ServiceEvent
 
@@ -11,7 +13,12 @@ class RequestHandlersProgressEvent(ServiceEvent):
     name = 'request_handlers_progress'
     routing_key_fmt = 'sysconfd.request_handlers.{uuid}.{status}'
 
-    def __init__(self, request_uuid: str, request_context: dict | None, status: str):
+    def __init__(
+        self,
+        request_uuid: Annotated[str, {'format': 'uuid'}],
+        request_context: dict | None,
+        status: str,
+    ):
         content = {
             'uuid': str(request_uuid),
             'status': status,
@@ -25,7 +32,13 @@ class AsteriskReloadProgressEvent(ServiceEvent):
     name = 'asterisk_reload_progress'
     routing_key_fmt = 'sysconfd.asterisk.reload.{uuid}.{status}'
 
-    def __init__(self, uuid: str, status: str, command: str, request_uuids: list[str]):
+    def __init__(
+        self,
+        uuid: Annotated[str, {'format': 'uuid'}],
+        status: str,
+        command: str,
+        request_uuids: list[str],
+    ):
         content = {
             'uuid': str(uuid),
             'status': status,

--- a/xivo_bus/resources/trunk/event.py
+++ b/xivo_bus/resources/trunk/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class TrunkCreatedEvent(TenantEvent):
@@ -11,7 +12,7 @@ class TrunkCreatedEvent(TenantEvent):
     name = 'trunk_created'
     routing_key_fmt = 'config.trunk.created'
 
-    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -21,7 +22,7 @@ class TrunkDeletedEvent(TenantEvent):
     name = 'trunk_deleted'
     routing_key_fmt = 'config.trunk.deleted'
 
-    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -31,7 +32,7 @@ class TrunkEditedEvent(TenantEvent):
     name = 'trunk_edited'
     routing_key_fmt = 'config.trunk.edited'
 
-    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
+    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -48,7 +49,7 @@ class TrunkStatusUpdatedEvent(TenantEvent):
         endpoint_name: str,
         endpoint_registered: bool,
         endpoint_current_call_count: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': trunk_id,

--- a/xivo_bus/resources/trunk/event.py
+++ b/xivo_bus/resources/trunk/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class TrunkCreatedEvent(TenantEvent):
@@ -12,7 +10,7 @@ class TrunkCreatedEvent(TenantEvent):
     name = 'trunk_created'
     routing_key_fmt = 'config.trunk.created'
 
-    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, trunk_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -22,7 +20,7 @@ class TrunkDeletedEvent(TenantEvent):
     name = 'trunk_deleted'
     routing_key_fmt = 'config.trunk.deleted'
 
-    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, trunk_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -32,7 +30,7 @@ class TrunkEditedEvent(TenantEvent):
     name = 'trunk_edited'
     routing_key_fmt = 'config.trunk.edited'
 
-    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, trunk_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -49,7 +47,7 @@ class TrunkStatusUpdatedEvent(TenantEvent):
         endpoint_name: str,
         endpoint_registered: bool,
         endpoint_current_call_count: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'id': trunk_id,

--- a/xivo_bus/resources/trunk/event.py
+++ b/xivo_bus/resources/trunk/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,7 @@ class TrunkCreatedEvent(TenantEvent):
     name = 'trunk_created'
     routing_key_fmt = 'config.trunk.created'
 
-    def __init__(self, trunk_id: int, tenant_uuid: str):
+    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +21,7 @@ class TrunkDeletedEvent(TenantEvent):
     name = 'trunk_deleted'
     routing_key_fmt = 'config.trunk.deleted'
 
-    def __init__(self, trunk_id: int, tenant_uuid: str):
+    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -29,7 +31,7 @@ class TrunkEditedEvent(TenantEvent):
     name = 'trunk_edited'
     routing_key_fmt = 'config.trunk.edited'
 
-    def __init__(self, trunk_id: int, tenant_uuid: str):
+    def __init__(self, trunk_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]):
         content = {'id': int(trunk_id)}
         super().__init__(content, tenant_uuid)
 
@@ -46,7 +48,7 @@ class TrunkStatusUpdatedEvent(TenantEvent):
         endpoint_name: str,
         endpoint_registered: bool,
         endpoint_current_call_count: int,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'id': trunk_id,

--- a/xivo_bus/resources/trunk_endpoint/event.py
+++ b/xivo_bus/resources/trunk_endpoint/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import EndpointCustomDict, EndpointIAXDict, EndpointSIPDict, TrunkDict
 
 
@@ -19,7 +17,7 @@ class TrunkEndpointSIPAssociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         sip: EndpointSIPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'trunk': trunk,
@@ -39,7 +37,7 @@ class TrunkEndpointSIPDissociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         sip: EndpointSIPDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'trunk': trunk,
@@ -59,7 +57,7 @@ class TrunkEndpointIAXAssociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         iax: EndpointIAXDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'trunk': trunk,
@@ -79,7 +77,7 @@ class TrunkEndpointIAXDissociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         iax: EndpointIAXDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'trunk': trunk,
@@ -99,7 +97,7 @@ class TrunkEndpointCustomAssociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         custom: EndpointCustomDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'trunk': trunk,
@@ -119,7 +117,7 @@ class TrunkEndpointCustomDissociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         custom: EndpointCustomDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'trunk': trunk,

--- a/xivo_bus/resources/trunk_endpoint/event.py
+++ b/xivo_bus/resources/trunk_endpoint/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import EndpointCustomDict, EndpointIAXDict, EndpointSIPDict, TrunkDict
@@ -12,7 +14,12 @@ class TrunkEndpointSIPAssociatedEvent(TenantEvent):
         'config.trunks.{trunk[id]}.endpoints.sip.{endpoint_sip[uuid]}.updated'
     )
 
-    def __init__(self, trunk: TrunkDict, sip: EndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        trunk: TrunkDict,
+        sip: EndpointSIPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'trunk': trunk,
             'endpoint_sip': sip,
@@ -27,7 +34,12 @@ class TrunkEndpointSIPDissociatedEvent(TenantEvent):
         'config.trunks.{trunk[id]}.endpoints.sip.{endpoint_sip[uuid]}.deleted'
     )
 
-    def __init__(self, trunk: TrunkDict, sip: EndpointSIPDict, tenant_uuid: str):
+    def __init__(
+        self,
+        trunk: TrunkDict,
+        sip: EndpointSIPDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'trunk': trunk,
             'endpoint_sip': sip,
@@ -42,7 +54,12 @@ class TrunkEndpointIAXAssociatedEvent(TenantEvent):
         'config.trunks.{trunk[id]}.endpoints.iax.{endpoint_iax[id]}.updated'
     )
 
-    def __init__(self, trunk: TrunkDict, iax: EndpointIAXDict, tenant_uuid: str):
+    def __init__(
+        self,
+        trunk: TrunkDict,
+        iax: EndpointIAXDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'trunk': trunk,
             'endpoint_iax': iax,
@@ -57,7 +74,12 @@ class TrunkEndpointIAXDissociatedEvent(TenantEvent):
         'config.trunks.{trunk[id]}.endpoints.iax.{endpoint_iax[id]}.deleted'
     )
 
-    def __init__(self, trunk: TrunkDict, iax: EndpointIAXDict, tenant_uuid: str):
+    def __init__(
+        self,
+        trunk: TrunkDict,
+        iax: EndpointIAXDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'trunk': trunk,
             'endpoint_iax': iax,
@@ -72,7 +94,12 @@ class TrunkEndpointCustomAssociatedEvent(TenantEvent):
         'config.trunks.{trunk[id]}.endpoints.custom.{endpoint_custom[id]}.updated'
     )
 
-    def __init__(self, trunk: TrunkDict, custom: EndpointCustomDict, tenant_uuid: str):
+    def __init__(
+        self,
+        trunk: TrunkDict,
+        custom: EndpointCustomDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'trunk': trunk,
             'endpoint_custom': custom,
@@ -87,7 +114,12 @@ class TrunkEndpointCustomDissociatedEvent(TenantEvent):
         'config.trunks.{trunk[id]}.endpoints.custom.{endpoint_custom[id]}.deleted'
     )
 
-    def __init__(self, trunk: TrunkDict, custom: EndpointCustomDict, tenant_uuid: str):
+    def __init__(
+        self,
+        trunk: TrunkDict,
+        custom: EndpointCustomDict,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'trunk': trunk,
             'endpoint_custom': custom,

--- a/xivo_bus/resources/trunk_endpoint/event.py
+++ b/xivo_bus/resources/trunk_endpoint/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import EndpointCustomDict, EndpointIAXDict, EndpointSIPDict, TrunkDict
 
 
@@ -18,7 +19,7 @@ class TrunkEndpointSIPAssociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         sip: EndpointSIPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'trunk': trunk,
@@ -38,7 +39,7 @@ class TrunkEndpointSIPDissociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         sip: EndpointSIPDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'trunk': trunk,
@@ -58,7 +59,7 @@ class TrunkEndpointIAXAssociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         iax: EndpointIAXDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'trunk': trunk,
@@ -78,7 +79,7 @@ class TrunkEndpointIAXDissociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         iax: EndpointIAXDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'trunk': trunk,
@@ -98,7 +99,7 @@ class TrunkEndpointCustomAssociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         custom: EndpointCustomDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'trunk': trunk,
@@ -118,7 +119,7 @@ class TrunkEndpointCustomDissociatedEvent(TenantEvent):
         self,
         trunk: TrunkDict,
         custom: EndpointCustomDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'trunk': trunk,

--- a/xivo_bus/resources/trunk_endpoint/types.py
+++ b/xivo_bus/resources/trunk_endpoint/types.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]
     name: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict
     registration_section_options: EndpointSIPRegistrationSectionOptionsDict
@@ -24,16 +26,16 @@ class EndpointSIPRegistrationSectionOptionsDict(TypedDict, total=False):
 
 class EndpointIAXDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
     name: str
 
 
 class EndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]
     interface: str
 
 
 class TrunkDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, Format('uuid')]

--- a/xivo_bus/resources/trunk_endpoint/types.py
+++ b/xivo_bus/resources/trunk_endpoint/types.py
@@ -1,14 +1,14 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     name: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict
     registration_section_options: EndpointSIPRegistrationSectionOptionsDict
@@ -24,16 +24,16 @@ class EndpointSIPRegistrationSectionOptionsDict(TypedDict, total=False):
 
 class EndpointIAXDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     name: str
 
 
 class EndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]
     interface: str
 
 
 class TrunkDict(TypedDict, total=False):
     id: int
-    tenant_uuid: str
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]

--- a/xivo_bus/resources/trunk_endpoint/types.py
+++ b/xivo_bus/resources/trunk_endpoint/types.py
@@ -3,14 +3,14 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr
     name: str
     auth_section_options: EndpointSIPAuthSectionOptionsDict
     registration_section_options: EndpointSIPRegistrationSectionOptionsDict
@@ -26,16 +26,16 @@ class EndpointSIPRegistrationSectionOptionsDict(TypedDict, total=False):
 
 class EndpointIAXDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr
     name: str
 
 
 class EndpointCustomDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr
     interface: str
 
 
 class TrunkDict(TypedDict, total=False):
     id: int
-    tenant_uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: UUIDStr

--- a/xivo_bus/resources/trunk_register/event.py
+++ b/xivo_bus/resources/trunk_register/event.py
@@ -1,5 +1,7 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 
@@ -9,7 +11,12 @@ class TrunkRegisterIAXAssociatedEvent(TenantEvent):
     name = 'trunk_register_iax_associated'
     routing_key_fmt = 'config.trunks.registers.iax.updated'
 
-    def __init__(self, trunk_id: int, register_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        trunk_id: int,
+        register_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {'trunk_id': trunk_id, 'register_id': register_id}
         super().__init__(content, tenant_uuid)
 
@@ -19,7 +26,12 @@ class TrunkRegisterIAXDissociatedEvent(TenantEvent):
     name = 'trunk_register_iax_dissociated'
     routing_key_fmt = 'config.trunks.registers.iax.deleted'
 
-    def __init__(self, trunk_id: int, register_id: int, tenant_uuid: str):
+    def __init__(
+        self,
+        trunk_id: int,
+        register_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'trunk_id': trunk_id,
             'register_id': register_id,

--- a/xivo_bus/resources/trunk_register/event.py
+++ b/xivo_bus/resources/trunk_register/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 
 
 class TrunkRegisterIAXAssociatedEvent(TenantEvent):
@@ -15,7 +16,7 @@ class TrunkRegisterIAXAssociatedEvent(TenantEvent):
         self,
         trunk_id: int,
         register_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {'trunk_id': trunk_id, 'register_id': register_id}
         super().__init__(content, tenant_uuid)
@@ -30,7 +31,7 @@ class TrunkRegisterIAXDissociatedEvent(TenantEvent):
         self,
         trunk_id: int,
         register_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'trunk_id': trunk_id,

--- a/xivo_bus/resources/trunk_register/event.py
+++ b/xivo_bus/resources/trunk_register/event.py
@@ -1,10 +1,8 @@
 # Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class TrunkRegisterIAXAssociatedEvent(TenantEvent):
@@ -16,7 +14,7 @@ class TrunkRegisterIAXAssociatedEvent(TenantEvent):
         self,
         trunk_id: int,
         register_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {'trunk_id': trunk_id, 'register_id': register_id}
         super().__init__(content, tenant_uuid)
@@ -31,7 +29,7 @@ class TrunkRegisterIAXDissociatedEvent(TenantEvent):
         self,
         trunk_id: int,
         register_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'trunk_id': trunk_id,

--- a/xivo_bus/resources/user/event.py
+++ b/xivo_bus/resources/user/event.py
@@ -6,16 +6,17 @@ from __future__ import annotations
 from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 
 
 class _BaseUserEvent(TenantEvent):
     def __init__(
         self,
         user_id: int,
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, Format('uuid')],
         subscription_type: str,
         created_at: str | None,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': int(user_id),
@@ -53,8 +54,8 @@ class UserFallbackEditedEvent(UserEvent):
     def __init__(
         self,
         user_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': int(user_id),
@@ -76,8 +77,8 @@ class UserServiceEditedEvent(UserEvent):
         user_id: int,
         service_name: str,
         service_enabled: bool,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         self.name = type(self).name.format(service_name=service_name)
         content = {
@@ -101,8 +102,8 @@ class UserForwardEditedEvent(UserEvent):
         forward_name: str,
         forward_enabled: bool,
         forward_dest: str,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         self.name = type(self).name.format(forward_name=forward_name)
         content = {

--- a/xivo_bus/resources/user/event.py
+++ b/xivo_bus/resources/user/event.py
@@ -3,20 +3,18 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class _BaseUserEvent(TenantEvent):
     def __init__(
         self,
         user_id: int,
-        user_uuid: Annotated[str, Format('uuid')],
+        user_uuid: UUIDStr,
         subscription_type: str,
         created_at: str | None,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'id': int(user_id),
@@ -54,8 +52,8 @@ class UserFallbackEditedEvent(UserEvent):
     def __init__(
         self,
         user_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'id': int(user_id),
@@ -77,8 +75,8 @@ class UserServiceEditedEvent(UserEvent):
         user_id: int,
         service_name: str,
         service_enabled: bool,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         self.name = type(self).name.format(service_name=service_name)
         content = {
@@ -102,8 +100,8 @@ class UserForwardEditedEvent(UserEvent):
         forward_name: str,
         forward_enabled: bool,
         forward_dest: str,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         self.name = type(self).name.format(forward_name=forward_name)
         content = {

--- a/xivo_bus/resources/user/event.py
+++ b/xivo_bus/resources/user/event.py
@@ -1,7 +1,9 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
+
+from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
 
@@ -10,10 +12,10 @@ class _BaseUserEvent(TenantEvent):
     def __init__(
         self,
         user_id: int,
-        user_uuid: str,
+        user_uuid: Annotated[str, {'format': 'uuid'}],
         subscription_type: str,
         created_at: str | None,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'id': int(user_id),
@@ -48,7 +50,12 @@ class UserFallbackEditedEvent(UserEvent):
     name = 'user_fallback_edited'
     routing_key_fmt = 'config.users.fallbacks.edited'
 
-    def __init__(self, user_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        user_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'id': int(user_id),
             'uuid': str(user_uuid),
@@ -69,8 +76,8 @@ class UserServiceEditedEvent(UserEvent):
         user_id: int,
         service_name: str,
         service_enabled: bool,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         self.name = type(self).name.format(service_name=service_name)
         content = {
@@ -94,8 +101,8 @@ class UserForwardEditedEvent(UserEvent):
         forward_name: str,
         forward_enabled: bool,
         forward_dest: str,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         self.name = type(self).name.format(forward_name=forward_name)
         content = {

--- a/xivo_bus/resources/user_agent/event.py
+++ b/xivo_bus/resources/user_agent/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import UserEvent
 
@@ -9,7 +11,12 @@ class UserAgentAssociatedEvent(UserEvent):
     name = 'user_agent_associated'
     routing_key_fmt = 'config.users.{user_uuid}.agents.updated'
 
-    def __init__(self, agent_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        agent_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'agent_id': agent_id,
@@ -22,7 +29,12 @@ class UserAgentDissociatedEvent(UserEvent):
     name = 'user_agent_dissociated'
     routing_key_fmt = 'config.users.{user_uuid}.agents.deleted'
 
-    def __init__(self, agent_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        agent_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'agent_id': agent_id,

--- a/xivo_bus/resources/user_agent/event.py
+++ b/xivo_bus/resources/user_agent/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 
 
 class UserAgentAssociatedEvent(UserEvent):
@@ -14,8 +15,8 @@ class UserAgentAssociatedEvent(UserEvent):
     def __init__(
         self,
         agent_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -32,8 +33,8 @@ class UserAgentDissociatedEvent(UserEvent):
     def __init__(
         self,
         agent_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/user_agent/event.py
+++ b/xivo_bus/resources/user_agent/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class UserAgentAssociatedEvent(UserEvent):
@@ -15,8 +13,8 @@ class UserAgentAssociatedEvent(UserEvent):
     def __init__(
         self,
         agent_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -33,8 +31,8 @@ class UserAgentDissociatedEvent(UserEvent):
     def __init__(
         self,
         agent_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/user_call_permission/event.py
+++ b/xivo_bus/resources/user_call_permission/event.py
@@ -1,10 +1,8 @@
 # Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class UserCallPermissionAssociatedEvent(UserEvent):
@@ -15,8 +13,8 @@ class UserCallPermissionAssociatedEvent(UserEvent):
     def __init__(
         self,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -33,8 +31,8 @@ class UserCallPermissionDissociatedEvent(UserEvent):
     def __init__(
         self,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/user_call_permission/event.py
+++ b/xivo_bus/resources/user_call_permission/event.py
@@ -1,5 +1,7 @@
-# Copyright 2016-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import UserEvent
 
@@ -9,7 +11,12 @@ class UserCallPermissionAssociatedEvent(UserEvent):
     name = 'user_call_permission_associated'
     routing_key_fmt = 'config.users.{user_uuid}.callpermissions.updated'
 
-    def __init__(self, call_permission_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call_permission_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'call_permission_id': call_permission_id,
@@ -22,7 +29,12 @@ class UserCallPermissionDissociatedEvent(UserEvent):
     name = 'user_call_permission_dissociated'
     routing_key_fmt = 'config.users.{user_uuid}.callpermissions.deleted'
 
-    def __init__(self, call_permission_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        call_permission_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'call_permission_id': call_permission_id,

--- a/xivo_bus/resources/user_call_permission/event.py
+++ b/xivo_bus/resources/user_call_permission/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 
 
 class UserCallPermissionAssociatedEvent(UserEvent):
@@ -14,8 +15,8 @@ class UserCallPermissionAssociatedEvent(UserEvent):
     def __init__(
         self,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -32,8 +33,8 @@ class UserCallPermissionDissociatedEvent(UserEvent):
     def __init__(
         self,
         call_permission_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/user_external_app/event.py
+++ b/xivo_bus/resources/user_external_app/event.py
@@ -1,5 +1,7 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent
 from .types import ExternalAppDict
@@ -10,7 +12,9 @@ class UserExternalAppCreatedEvent(TenantEvent):
     name = 'user_external_app_created'
     routing_key_fmt = 'config.user_external_apps.created'
 
-    def __init__(self, app: ExternalAppDict, tenant_uuid: str):
+    def __init__(
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(app, tenant_uuid)
 
 
@@ -19,7 +23,9 @@ class UserExternalAppDeletedEvent(TenantEvent):
     name = 'user_external_app_deleted'
     routing_key_fmt = 'config.user_external_apps.deleted'
 
-    def __init__(self, app: ExternalAppDict, tenant_uuid: str):
+    def __init__(
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(app, tenant_uuid)
 
 
@@ -28,5 +34,7 @@ class UserExternalAppEditedEvent(TenantEvent):
     name = 'user_external_app_edited'
     routing_key_fmt = 'config.user_external_apps.edited'
 
-    def __init__(self, app: ExternalAppDict, tenant_uuid: str):
+    def __init__(
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         super().__init__(app, tenant_uuid)

--- a/xivo_bus/resources/user_external_app/event.py
+++ b/xivo_bus/resources/user_external_app/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent
+from ..common.types import Format
 from .types import ExternalAppDict
 
 
@@ -13,7 +14,7 @@ class UserExternalAppCreatedEvent(TenantEvent):
     routing_key_fmt = 'config.user_external_apps.created'
 
     def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(app, tenant_uuid)
 
@@ -24,7 +25,7 @@ class UserExternalAppDeletedEvent(TenantEvent):
     routing_key_fmt = 'config.user_external_apps.deleted'
 
     def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(app, tenant_uuid)
 
@@ -35,6 +36,6 @@ class UserExternalAppEditedEvent(TenantEvent):
     routing_key_fmt = 'config.user_external_apps.edited'
 
     def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
     ):
         super().__init__(app, tenant_uuid)

--- a/xivo_bus/resources/user_external_app/event.py
+++ b/xivo_bus/resources/user_external_app/event.py
@@ -1,10 +1,8 @@
 # Copyright 2020-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import ExternalAppDict
 
 
@@ -13,9 +11,7 @@ class UserExternalAppCreatedEvent(TenantEvent):
     name = 'user_external_app_created'
     routing_key_fmt = 'config.user_external_apps.created'
 
-    def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, app: ExternalAppDict, tenant_uuid: UUIDStr):
         super().__init__(app, tenant_uuid)
 
 
@@ -24,9 +20,7 @@ class UserExternalAppDeletedEvent(TenantEvent):
     name = 'user_external_app_deleted'
     routing_key_fmt = 'config.user_external_apps.deleted'
 
-    def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, app: ExternalAppDict, tenant_uuid: UUIDStr):
         super().__init__(app, tenant_uuid)
 
 
@@ -35,7 +29,5 @@ class UserExternalAppEditedEvent(TenantEvent):
     name = 'user_external_app_edited'
     routing_key_fmt = 'config.user_external_apps.edited'
 
-    def __init__(
-        self, app: ExternalAppDict, tenant_uuid: Annotated[str, Format('uuid')]
-    ):
+    def __init__(self, app: ExternalAppDict, tenant_uuid: UUIDStr):
         super().__init__(app, tenant_uuid)

--- a/xivo_bus/resources/user_group/event.py
+++ b/xivo_bus/resources/user_group/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 
 
 class UserGroupsAssociatedEvent(UserEvent):
@@ -14,8 +15,8 @@ class UserGroupsAssociatedEvent(UserEvent):
     def __init__(
         self,
         group_ids: list[int],
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/user_group/event.py
+++ b/xivo_bus/resources/user_group/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import UserEvent
 
@@ -9,7 +11,12 @@ class UserGroupsAssociatedEvent(UserEvent):
     name = 'user_groups_associated'
     routing_key_fmt = 'config.users.groups.updated'
 
-    def __init__(self, group_ids: list[int], tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        group_ids: list[int],
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'group_ids': group_ids,

--- a/xivo_bus/resources/user_group/event.py
+++ b/xivo_bus/resources/user_group/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class UserGroupsAssociatedEvent(UserEvent):
@@ -15,8 +13,8 @@ class UserGroupsAssociatedEvent(UserEvent):
     def __init__(
         self,
         group_ids: list[int],
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/user_line/event.py
+++ b/xivo_bus/resources/user_line/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import LineDict, UserDict
 
 
@@ -19,7 +17,7 @@ class UserLineAssociatedEvent(UserEvent):
         line: LineDict,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'line': line,
@@ -41,7 +39,7 @@ class UserLineDissociatedEvent(UserEvent):
         line: LineDict,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
     ):
         content = {
             'line': line,

--- a/xivo_bus/resources/user_line/event.py
+++ b/xivo_bus/resources/user_line/event.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import UserEvent
 from .types import LineDict, UserDict
@@ -16,7 +18,7 @@ class UserLineAssociatedEvent(UserEvent):
         line: LineDict,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'line': line,
@@ -38,7 +40,7 @@ class UserLineDissociatedEvent(UserEvent):
         line: LineDict,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'line': line,

--- a/xivo_bus/resources/user_line/event.py
+++ b/xivo_bus/resources/user_line/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 from .types import LineDict, UserDict
 
 
@@ -18,7 +19,7 @@ class UserLineAssociatedEvent(UserEvent):
         line: LineDict,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'line': line,
@@ -40,7 +41,7 @@ class UserLineDissociatedEvent(UserEvent):
         line: LineDict,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'line': line,

--- a/xivo_bus/resources/user_line/types.py
+++ b/xivo_bus/resources/user_line/types.py
@@ -1,9 +1,9 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 
 class EndpointCustomDict(TypedDict, total=False):
@@ -15,7 +15,7 @@ class EndpointSCCPDict(TypedDict, total=False):
 
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
 
 
 class LineDict(TypedDict, total=False):
@@ -28,5 +28,5 @@ class LineDict(TypedDict, total=False):
 
 class UserDict(TypedDict, total=False):
     id: int
-    uuid: str
-    tenant_uuid: str
+    uuid: Annotated[str, {'format': 'uuid'}]
+    tenant_uuid: Annotated[str, {'format': 'uuid'}]

--- a/xivo_bus/resources/user_line/types.py
+++ b/xivo_bus/resources/user_line/types.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from typing import Annotated, TypedDict
+from typing import TypedDict
 
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class EndpointCustomDict(TypedDict, total=False):
@@ -17,7 +17,7 @@ class EndpointSCCPDict(TypedDict, total=False):
 
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
 
 
 class LineDict(TypedDict, total=False):
@@ -30,5 +30,5 @@ class LineDict(TypedDict, total=False):
 
 class UserDict(TypedDict, total=False):
     id: int
-    uuid: Annotated[str, Format('uuid')]
-    tenant_uuid: Annotated[str, Format('uuid')]
+    uuid: UUIDStr
+    tenant_uuid: UUIDStr

--- a/xivo_bus/resources/user_line/types.py
+++ b/xivo_bus/resources/user_line/types.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, TypedDict
 
+from ..common.types import Format
+
 
 class EndpointCustomDict(TypedDict, total=False):
     id: int
@@ -15,7 +17,7 @@ class EndpointSCCPDict(TypedDict, total=False):
 
 
 class EndpointSIPDict(TypedDict, total=False):
-    uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
 
 
 class LineDict(TypedDict, total=False):
@@ -28,5 +30,5 @@ class LineDict(TypedDict, total=False):
 
 class UserDict(TypedDict, total=False):
     id: int
-    uuid: Annotated[str, {'format': 'uuid'}]
-    tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    uuid: Annotated[str, Format('uuid')]
+    tenant_uuid: Annotated[str, Format('uuid')]

--- a/xivo_bus/resources/user_line_extension/event.py
+++ b/xivo_bus/resources/user_line_extension/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 
 
 class _BaseUserLineExtensionEvent(UserEvent):
@@ -15,8 +16,8 @@ class _BaseUserLineExtensionEvent(UserEvent):
         extension_id: int,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'id': int(user_line_extension_id),

--- a/xivo_bus/resources/user_line_extension/event.py
+++ b/xivo_bus/resources/user_line_extension/event.py
@@ -1,7 +1,9 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from xivo_bus.resources.common.event import UserEvent
+from typing import Annotated
+
+from ..common.event import UserEvent
 
 
 class _BaseUserLineExtensionEvent(UserEvent):
@@ -13,8 +15,8 @@ class _BaseUserLineExtensionEvent(UserEvent):
         extension_id: int,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'id': int(user_line_extension_id),

--- a/xivo_bus/resources/user_line_extension/event.py
+++ b/xivo_bus/resources/user_line_extension/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class _BaseUserLineExtensionEvent(UserEvent):
@@ -16,8 +14,8 @@ class _BaseUserLineExtensionEvent(UserEvent):
         extension_id: int,
         main_user: bool,
         main_line: bool,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'id': int(user_line_extension_id),

--- a/xivo_bus/resources/user_schedule/event.py
+++ b/xivo_bus/resources/user_schedule/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 
 
 class UserScheduleAssociatedEvent(UserEvent):
@@ -14,8 +15,8 @@ class UserScheduleAssociatedEvent(UserEvent):
     def __init__(
         self,
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -32,8 +33,8 @@ class UserScheduleDissociatedEvent(UserEvent):
     def __init__(
         self,
         schedule_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/user_schedule/event.py
+++ b/xivo_bus/resources/user_schedule/event.py
@@ -1,5 +1,7 @@
-# Copyright 2017-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import UserEvent
 
@@ -9,7 +11,12 @@ class UserScheduleAssociatedEvent(UserEvent):
     name = 'user_schedule_associated'
     routing_key_fmt = 'config.users.schedules.updated'
 
-    def __init__(self, schedule_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'schedule_id': schedule_id,
@@ -22,7 +29,12 @@ class UserScheduleDissociatedEvent(UserEvent):
     name = 'user_schedule_dissociated'
     routing_key_fmt = 'config.users.schedules.deleted'
 
-    def __init__(self, schedule_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        schedule_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'schedule_id': schedule_id,

--- a/xivo_bus/resources/user_schedule/event.py
+++ b/xivo_bus/resources/user_schedule/event.py
@@ -1,10 +1,8 @@
 # Copyright 2017-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class UserScheduleAssociatedEvent(UserEvent):
@@ -15,8 +13,8 @@ class UserScheduleAssociatedEvent(UserEvent):
     def __init__(
         self,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -33,8 +31,8 @@ class UserScheduleDissociatedEvent(UserEvent):
     def __init__(
         self,
         schedule_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/user_voicemail/event.py
+++ b/xivo_bus/resources/user_voicemail/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import UserEvent
+from ..common.types import Format
 
 
 class UserVoicemailAssociatedEvent(UserEvent):
@@ -14,8 +15,8 @@ class UserVoicemailAssociatedEvent(UserEvent):
     def __init__(
         self,
         voicemail_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -32,8 +33,8 @@ class UserVoicemailDissociatedEvent(UserEvent):
     def __init__(
         self,
         voicemail_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': user_uuid,

--- a/xivo_bus/resources/user_voicemail/event.py
+++ b/xivo_bus/resources/user_voicemail/event.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import UserEvent
 
@@ -9,7 +11,12 @@ class UserVoicemailAssociatedEvent(UserEvent):
     name = 'user_voicemail_associated'
     routing_key_fmt = 'config.users.{user_uuid}.voicemails.updated'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        voicemail_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'voicemail_id': int(voicemail_id),
@@ -22,7 +29,12 @@ class UserVoicemailDissociatedEvent(UserEvent):
     name = 'user_voicemail_dissociated'
     routing_key_fmt = 'config.users.{user_uuid}.voicemails.deleted'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        voicemail_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': user_uuid,
             'voicemail_id': int(voicemail_id),

--- a/xivo_bus/resources/user_voicemail/event.py
+++ b/xivo_bus/resources/user_voicemail/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 
 
 class UserVoicemailAssociatedEvent(UserEvent):
@@ -15,8 +13,8 @@ class UserVoicemailAssociatedEvent(UserEvent):
     def __init__(
         self,
         voicemail_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -33,8 +31,8 @@ class UserVoicemailDissociatedEvent(UserEvent):
     def __init__(
         self,
         voicemail_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': user_uuid,

--- a/xivo_bus/resources/voicemail/event.py
+++ b/xivo_bus/resources/voicemail/event.py
@@ -1,10 +1,8 @@
 # Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from typing import Annotated
-
 from ..common.event import TenantEvent, UserEvent
-from ..common.types import Format
+from ..common.types import UUIDStr
 from .types import VoicemailMessageDict
 
 
@@ -13,7 +11,7 @@ class VoicemailCreatedEvent(TenantEvent):
     name = 'voicemail_created'
     routing_key_fmt = 'config.voicemail.created'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, voicemail_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -23,7 +21,7 @@ class VoicemailDeletedEvent(TenantEvent):
     name = 'voicemail_deleted'
     routing_key_fmt = 'config.voicemail.deleted'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, voicemail_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -33,7 +31,7 @@ class VoicemailEditedEvent(TenantEvent):
     name = 'voicemail_edited'
     routing_key_fmt = 'config.voicemail.edited'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
+    def __init__(self, voicemail_id: int, tenant_uuid: UUIDStr):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -46,8 +44,8 @@ class UserVoicemailEditedEvent(UserEvent):
     def __init__(
         self,
         voicemail_id: int,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -67,8 +65,8 @@ class UserVoicemailMessageCreatedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -90,8 +88,8 @@ class UserVoicemailMessageUpdatedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -113,8 +111,8 @@ class UserVoicemailMessageDeletedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: Annotated[str, Format('uuid')],
-        user_uuid: Annotated[str, Format('uuid')],
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/voicemail/event.py
+++ b/xivo_bus/resources/voicemail/event.py
@@ -1,5 +1,7 @@
-# Copyright 2013-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2013-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
 from .types import VoicemailMessageDict
@@ -10,7 +12,9 @@ class VoicemailCreatedEvent(TenantEvent):
     name = 'voicemail_created'
     routing_key_fmt = 'config.voicemail.created'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: str):
+    def __init__(
+        self, voicemail_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -20,7 +24,9 @@ class VoicemailDeletedEvent(TenantEvent):
     name = 'voicemail_deleted'
     routing_key_fmt = 'config.voicemail.deleted'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: str):
+    def __init__(
+        self, voicemail_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -30,7 +36,9 @@ class VoicemailEditedEvent(TenantEvent):
     name = 'voicemail_edited'
     routing_key_fmt = 'config.voicemail.edited'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: str):
+    def __init__(
+        self, voicemail_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
+    ):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -40,7 +48,12 @@ class UserVoicemailEditedEvent(UserEvent):
     name = 'user_voicemail_edited'
     routing_key_fmt = 'config.users.{user_uuid}.voicemails.edited'
 
-    def __init__(self, voicemail_id: int, tenant_uuid: str, user_uuid: str):
+    def __init__(
+        self,
+        voicemail_id: int,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
+    ):
         content = {
             'user_uuid': str(user_uuid),
             'voicemail_id': voicemail_id,
@@ -59,8 +72,8 @@ class UserVoicemailMessageCreatedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -82,8 +95,8 @@ class UserVoicemailMessageUpdatedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -105,8 +118,8 @@ class UserVoicemailMessageDeletedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: str,
-        user_uuid: str,
+        tenant_uuid: Annotated[str, {'format': 'uuid'}],
+        user_uuid: Annotated[str, {'format': 'uuid'}],
     ):
         content = {
             'user_uuid': str(user_uuid),

--- a/xivo_bus/resources/voicemail/event.py
+++ b/xivo_bus/resources/voicemail/event.py
@@ -4,6 +4,7 @@
 from typing import Annotated
 
 from ..common.event import TenantEvent, UserEvent
+from ..common.types import Format
 from .types import VoicemailMessageDict
 
 
@@ -12,9 +13,7 @@ class VoicemailCreatedEvent(TenantEvent):
     name = 'voicemail_created'
     routing_key_fmt = 'config.voicemail.created'
 
-    def __init__(
-        self, voicemail_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, voicemail_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -24,9 +23,7 @@ class VoicemailDeletedEvent(TenantEvent):
     name = 'voicemail_deleted'
     routing_key_fmt = 'config.voicemail.deleted'
 
-    def __init__(
-        self, voicemail_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, voicemail_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -36,9 +33,7 @@ class VoicemailEditedEvent(TenantEvent):
     name = 'voicemail_edited'
     routing_key_fmt = 'config.voicemail.edited'
 
-    def __init__(
-        self, voicemail_id: int, tenant_uuid: Annotated[str, {'format': 'uuid'}]
-    ):
+    def __init__(self, voicemail_id: int, tenant_uuid: Annotated[str, Format('uuid')]):
         content = {'id': int(voicemail_id)}
         super().__init__(content, tenant_uuid)
 
@@ -51,8 +46,8 @@ class UserVoicemailEditedEvent(UserEvent):
     def __init__(
         self,
         voicemail_id: int,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -72,8 +67,8 @@ class UserVoicemailMessageCreatedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -95,8 +90,8 @@ class UserVoicemailMessageUpdatedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),
@@ -118,8 +113,8 @@ class UserVoicemailMessageDeletedEvent(UserEvent):
         message_id: str,
         voicemail_id: int,
         message: VoicemailMessageDict,
-        tenant_uuid: Annotated[str, {'format': 'uuid'}],
-        user_uuid: Annotated[str, {'format': 'uuid'}],
+        tenant_uuid: Annotated[str, Format('uuid')],
+        user_uuid: Annotated[str, Format('uuid')],
     ):
         content = {
             'user_uuid': str(user_uuid),


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-bus/pull/92

Rewrite parser to generate AsyncAPI specs from annotations

- Added annotated type for strings to specify their types (normal string, date, date-time or uuid)