### PR TITLE
debian: force version of typing dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,9 @@ X-Python3-Version: >= 3.9
 Package: xivo-bus-python3
 Architecture: all
 Section: python
-Depends: ${python3:Depends}, ${misc:Depends}
+Depends: ${python3:Depends},
+         ${misc:Depends},
+         python3-typing-extensions (>= 4.4.0)
 Description: Wazo message bus library - Python 3
  Wazo is a system based on a powerful IPBX, to bring an easy to
  install solution for telephony and related services.


### PR DESCRIPTION
Why:

* Installing the package does not upgrade python3-typing-extension
* version 4.4.0 is only available on wazo debian repo, bullseye has
  3.7.4
* version 3.7.4 is too old for xivo-bus typing code